### PR TITLE
Crash game in init if no .rmdp files are found

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -99,6 +99,10 @@ void Game::init() {
 		//Threads.add([=](){ResMan.indexArchive(binFile, rmdpFile);});
 		ResMan.indexArchive(binFile, rmdpFile);
 	}
+
+	if (identifiers.empty())
+		throw std::runtime_error("No .rmdp files found in the set data path, exiting ...");
+
 	/*ResMan.indexArchive(_path + "/ep999-000.bin", _path + "/ep999-000.rmdp");
 	identifiers.emplace_back("ep999-000");*/
 


### PR DESCRIPTION
This prevents the game segfaulting later on, which is less desirable as it does not provide an error message for the user what went wrong.

Closes https://github.com/OpenAWE-Project/OpenAWE/issues/5