### PR TITLE
Add build and run instructions for Linux to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,74 @@ portable manner. The secondary goal is to also allow the successor games, Quantu
 working with the same technical foundation. The code stands under the [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later) License except for the libraries contained
 the folder 3rdparty.
 
+
+Building
+--------
+Make sure to not include the `$` when running these. It signifies that the commands should be run as your user, not root.
+Commands that should be run as root (with sudo) are marked with a `#`.
+
+```bash
+$ git clone https://github.com/OpenAWE-Project/OpenAWE.git --recurse-submodules
+$ cd OpenAWE
+$ mkdir build
+$ cd build
+```
+
+The development files of the following dependencies need to be installed to build OpenAWE. The way these are acquired
+varies depending on your operating system (and in the case of Linux, distribution):
+
+ - ZLIB
+ - GLFW
+ - GLEW
+ - GLM
+ - LibXml2
+ - OpenGL
+ - OpenAL
+ - Bullet
+ - FMT
+ - OGG
+ - Theora
+ - GTest
+ - spdlog
+
+The following dependencies can either come from your system or you can use them through the git submodules. Assuming
+you cloned the repository with `--recurse-submodules` as instructed above you will have these available through git
+submodules already:
+
+ - EnTT
+ - cxxopts
+
+To use these from your system instead of the submodule you can set `USE_SYSTEM_ENTT` and `USE_SYSTEM_CXXOPTS`,
+respectively.
+
+Next step is to configure CMake and build. The `cmake` invocation will fail if you don't have all aforementioned
+dependencies configured on your system. This can be useful to check if you've installed everything as it tells you
+what it didn't find:
+
+```bash
+$ cmake ..
+$ make
+```
+
+Assuming these steps went well, you should now have built OpenAWE.
+
+You can then optionally install OpenAWE like so:
+
+```bash
+$ sudo make install
+```
+
+
+Usage
+-----
+To run OpenAWE, do something like this. Note that you need to replace the path with the actual path to your Alan Wake
+installation's data directory, and that only Alan Wake's American Nightmare will work at the moment.
+
+```bash
+$ ./awe -p /path/to/the/alan/wake/data/directory
+```
+
+
 Screenshots
 -----------
 ![Alan Wakes American Nightmare 1](screenshots/awan1.png)


### PR DESCRIPTION
This adds some rudimentary build and run instructions for Linux. Feel free to have opinions about their verbosity.