### PR TITLE
Add missing #include in theora.cpp

### DIFF
--- a/src/video/codecs/theora.cpp
+++ b/src/video/codecs/theora.cpp
@@ -2,6 +2,7 @@
 // Created by patrick on 25.05.20.
 //
 
+#include <algorithm>
 #include <cstring>
 #include <stdexcept>
 #include <map>


### PR DESCRIPTION
This PR just adds a missing include to theora.cpp which was causing a compilation error on my machine due to the use of `std::clamp`.