### PR TITLE
Rework RMDPArchive class to remove redundancies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # CLion Files
 .idea
 cmake-build-*
+# VS Code files
+.vscode
+.clangd
 
 # Engine files
 *.bin

--- a/src/awe/path.h
+++ b/src/awe/path.h
@@ -18,49 +18,27 @@
  * along with OpenAWE. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <sstream>
-#include <iostream>
+#ifndef AWE_PATH_H
+#define AWE_PATH_H
 
-#include <zlib.h>
+#include <string>
 
-#include "strutil.h"
+#include "src/common/strutil.h"
 
-namespace Common {
+namespace AWE {
 
-std::string toLower(std::string str) {
-	std::stringstream ss;
-
-	for (const auto &c : str) {
-		ss << static_cast<char>(std::tolower(c));
-	}
-
-	return ss.str();
+/*!
+ * An utility function that normalizes file path by:
+ * - replacing \ with /
+ * - lowercasing the path
+ */
+inline std::string getNormalizedPath(const std::string &path) {
+	std::string lower = Common::toLower(path);
+	uint64_t pos = std::string::npos;
+	while ((pos = lower.find("\\")) != std::string::npos) lower.replace(pos, 1, "/", 1);
+	return lower;
 }
 
-std::string toUpper(std::string str) {
-	std::stringstream ss;
+};
 
-	for (const auto &c : str) {
-		ss << static_cast<char>(std::toupper(c));
-	}
-
-	return ss.str();
-}
-
-bool contains(const std::string &str, const std::string &s) {
-	return str.find(s) != std::string::npos;
-}
-
-std::vector<std::string> split(const std::string &str, const std::regex &split) {
-	std::vector<std::string> result;
-
-	std::copy(
-			std::sregex_token_iterator(str.begin(), str.end(), split, -1),
-			std::sregex_token_iterator(),
-			std::back_inserter(result)
-	);
-
-	return result;
-}
-
-}
+#endif // AWE_PATH_H

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -19,13 +19,13 @@
  */
 
 #include <cstdint>
-#include <libintl.h>
+#include <cassert>
 #include <optional>
-#include <fmt/format.h>
 #include <regex>
 #include <vector>
+
+#include <fmt/format.h>
 #include <zlib.h>
-#include <assert.h>
 
 #include "src/common/endianreadstream.h"
 #include "src/common/strutil.h"

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -96,13 +96,6 @@ std::optional<RMDPArchive::FolderEntry> RMDPArchive::findDirectory(std::string &
 	return folder;
 }
 
-std::string RMDPArchive::getNormalizedPath(const std::string &path) const{
-	std::string lower = Common::toLower(path);
-	uint64_t pos = std::string::npos;
-	while ((pos = lower.find("\\")) != std::string::npos) lower.replace(pos, 1, "/", 1);
-	return (_pathPrefix ? "d:/data/" : "") + lower;
-}
-
 std::optional<RMDPArchive::FileEntry> RMDPArchive::findFile(const FolderEntry &folder, const uint32_t nameHash) const {
 	if (folder.nextFile == kNoEntry)
 		return {};
@@ -117,7 +110,7 @@ std::optional<RMDPArchive::FileEntry> RMDPArchive::findFile(const FolderEntry &f
 }
 
 std::vector<size_t> RMDPArchive::getDirectoryResources(const std::string &directory) {
-	std::string path = this->getNormalizedPath(directory);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(directory);
 	auto maybeFolder = this->findDirectory(path);
 	if (!maybeFolder) return {};
 	FolderEntry folder = *maybeFolder;
@@ -171,7 +164,7 @@ std::string RMDPArchive::getResourcePath(size_t index) const {
 }
 
 Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
-	std::string path = this->getNormalizedPath(rid);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(rid);
 	// Extract and separate file name from the rest of the path
 	uint64_t lastSlashPos = path.rfind("/");
 	std::string filename = path.substr(lastSlashPos + 1);
@@ -199,7 +192,7 @@ Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
 }
 
 bool RMDPArchive::hasResource(const std::string &rid) const {
-	std::string path = this->getNormalizedPath(rid);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(rid);
 	// Extract and separate file name from the rest of the path
 	uint64_t lastSlashPos = path.rfind("/");
 	std::string filename = path.substr(lastSlashPos + 1);
@@ -215,7 +208,7 @@ bool RMDPArchive::hasResource(const std::string &rid) const {
 }
 
 bool RMDPArchive::hasDirectory(const std::string &directory) const {
-	std::string path = this->getNormalizedPath(directory);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(directory);
 	auto maybeFolder = this->findDirectory(path);
 	return maybeFolder.has_value();
 }

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -27,6 +27,7 @@
 #include <fmt/format.h>
 #include <zlib.h>
 
+#include "src/awe/path.h"
 #include "src/common/endianreadstream.h"
 #include "src/common/strutil.h"
 #include "src/common/memreadstream.h"
@@ -133,7 +134,7 @@ std::optional<RMDPArchive::FileEntry> RMDPArchive::findFile(const FolderEntry &f
 }
 
 std::vector<size_t> RMDPArchive::getDirectoryResources(const std::string &directory) {
-	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(directory);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(directory);
 	auto maybeFolder = this->findDirectory(path);
 	if (!maybeFolder) return {};
 	FolderEntry folder = *maybeFolder;
@@ -188,7 +189,7 @@ std::string RMDPArchive::getResourcePath(size_t index) const {
 }
 
 Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
-	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(rid);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(rid);
 	// Extract and separate file name from the rest of the path
 	auto pathHashes = this->getPathHashes(path);
 	uint32_t fileHash = pathHashes.back();
@@ -215,7 +216,7 @@ Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
 }
 
 bool RMDPArchive::hasResource(const std::string &rid) const {
-	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(rid);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(rid);
 	// Extract and separate file name from the rest of the path
 	auto pathHashes = this->getPathHashes(path);
 	uint32_t fileHash = pathHashes.back();
@@ -230,7 +231,7 @@ bool RMDPArchive::hasResource(const std::string &rid) const {
 }
 
 bool RMDPArchive::hasDirectory(const std::string &directory) const {
-	std::string path = (_pathPrefix ? "d:/data/" : "") + Common::getNormalizedPath(directory);
+	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(directory);
 	auto maybeFolder = this->findDirectory(path);
 	return maybeFolder.has_value();
 }

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -98,7 +98,7 @@ std::optional<RMDPArchive::FolderEntry> RMDPArchive::findDirectory(const std::ve
 		folder = _folderEntries[folder.nextLowerFolder];
 
 		while (nameHash != folder.nameHash) {
-			if (EXTEND_INT(folder.nextNeighbourFolder) == kNoEntry64)
+			if (folder.nextNeighbourFolder == kNoEntry64)
 				return {};
 			folder = _folderEntries[folder.nextNeighbourFolder];
 		}
@@ -167,7 +167,7 @@ std::string RMDPArchive::getResourcePath(size_t index) const {
 	path = folderEntry.name + "/" + path;
 
 	// Iterate over all preceeding folder entries
-	while (EXTEND_INT(folderEntry.prevFolder) != kNoEntry64) {
+	while (folderEntry.prevFolder != kNoEntry64) {
 		folderEntry = _folderEntries[folderEntry.prevFolder];
 		if (!folderEntry.name.empty())
 			path = folderEntry.name + "/" + path;
@@ -260,7 +260,9 @@ void RMDPArchive::loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream
 	for (auto &entry : _folderEntries) {
 		entry.nameHash = end.readUint32();
 		entry.nextNeighbourFolder = end.readUint32();
+		entry.nextNeighbourFolder = EXTEND_INT(entry.nextNeighbourFolder);
 		entry.prevFolder = end.readUint32();
+		entry.prevFolder = EXTEND_INT(entry.prevFolder);
 
 		bin->skip(4); // Unknown value
 
@@ -312,7 +314,9 @@ void RMDPArchive::loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream
 	for (auto &entry : _folderEntries) {
 		entry.nameHash = end.readUint32();
 		entry.nextNeighbourFolder = end.readUint32();
+		entry.nextNeighbourFolder = EXTEND_INT(entry.nextNeighbourFolder);
 		entry.prevFolder = end.readUint32();
+		entry.prevFolder = EXTEND_INT(entry.prevFolder);
 
 		bin->skip(4); // Unknown value
 

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -82,7 +82,7 @@ std::optional<RMDPArchive::FolderEntry> RMDPArchive::findDirectory(std::string &
 	FolderEntry folder = _folderEntries.front();
 	if (path.empty()) return folder;
 
-	auto pathHashes = this->getPathHashes(path);
+	auto pathHashes = getPathHashes(path);
 
 	for (uint32_t nameHash : pathHashes) {
 		if (folder.nextLowerFolder == kNoEntry)
@@ -135,7 +135,7 @@ std::optional<RMDPArchive::FileEntry> RMDPArchive::findFile(const FolderEntry &f
 
 std::vector<size_t> RMDPArchive::getDirectoryResources(const std::string &directory) {
 	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(directory);
-	auto maybeFolder = this->findDirectory(path);
+	auto maybeFolder = findDirectory(path);
 	if (!maybeFolder) return {};
 	FolderEntry folder = *maybeFolder;
 
@@ -191,18 +191,18 @@ std::string RMDPArchive::getResourcePath(size_t index) const {
 Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
 	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(rid);
 	// Extract and separate file name from the rest of the path
-	auto pathHashes = this->getPathHashes(path);
+	auto pathHashes = getPathHashes(path);
 	uint32_t fileHash = pathHashes.back();
 	pathHashes.pop_back();
 
-	auto maybeFolder = this->findDirectory(pathHashes);
+	auto maybeFolder = findDirectory(pathHashes);
 	if (!maybeFolder) return nullptr;
 	FolderEntry folder = *maybeFolder;
 
 	if (folder.nextFile == kNoEntry)
 		return nullptr;
 
-	auto maybeFile = this->findFile(folder, fileHash);
+	auto maybeFile = findFile(folder, fileHash);
 	if (!maybeFile) return nullptr;
 	FileEntry file = *maybeFile;
 
@@ -218,21 +218,21 @@ Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
 bool RMDPArchive::hasResource(const std::string &rid) const {
 	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(rid);
 	// Extract and separate file name from the rest of the path
-	auto pathHashes = this->getPathHashes(path);
+	auto pathHashes = getPathHashes(path);
 	uint32_t fileHash = pathHashes.back();
 	pathHashes.pop_back();
 
-	auto maybeFolder = this->findDirectory(pathHashes);
+	auto maybeFolder = findDirectory(pathHashes);
 	if (!maybeFolder) return false;
 	FolderEntry folder = *maybeFolder;
 
-	auto maybeFile = this->findFile(folder, fileHash);
+	auto maybeFile = findFile(folder, fileHash);
 	return maybeFile.has_value();
 }
 
 bool RMDPArchive::hasDirectory(const std::string &directory) const {
 	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(directory);
-	auto maybeFolder = this->findDirectory(path);
+	auto maybeFolder = findDirectory(path);
 	return maybeFolder.has_value();
 }
 
@@ -259,7 +259,7 @@ RMDPArchive::FolderEntry RMDPArchive::readFolder(Common::ReadStream *bin, Common
 	bin->skip(4); // Unknown value
 
 	uint32_t nameOffset = end.readUint32();
-	entry.name = this->readEntryName(bin, nameOffset, nameSize);
+	entry.name = readEntryName(bin, nameOffset, nameSize);
 
 	entry.nextLowerFolder = end.readUint32();
 	entry.nextFile = end.readUint32();
@@ -283,7 +283,7 @@ void RMDPArchive::loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream
 	_fileEntries.resize(numFiles);
 
 	for (auto &entry : _folderEntries)
-		entry = this->readFolder(bin, end, nameSize);
+		entry = readFolder(bin, end, nameSize);
 
 	for (auto &entry : _fileEntries) {
 		entry.nameHash = end.readUint32();
@@ -292,7 +292,7 @@ void RMDPArchive::loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream
 		entry.flags = end.readUint32();
 
 		uint32_t nameOffset = end.readUint32();
-		entry.name = this->readEntryName(bin, nameOffset, nameSize);
+		entry.name = readEntryName(bin, nameOffset, nameSize);
 
 		uint32_t testHash = Common::crc32(Common::toLower(entry.name));
 		if (entry.nameHash != testHash)
@@ -324,7 +324,7 @@ void RMDPArchive::loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream
 	_fileEntries.resize(numFiles);
 
 	for (auto &entry : _folderEntries) 
-		entry = this->readFolder(bin, end, nameSize);
+		entry = readFolder(bin, end, nameSize);
 
 	for (auto &entry : _fileEntries) {
 		entry.nameHash = end.readUint32();
@@ -333,7 +333,7 @@ void RMDPArchive::loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream
 		entry.flags = end.readUint32();
 
 		uint32_t nameOffset = end.readUint32();
-		entry.name = this->readEntryName(bin, nameOffset, nameSize);
+		entry.name = readEntryName(bin, nameOffset, nameSize);
 
 		uint32_t testHash = Common::crc32(Common::toLower(entry.name));
 		if (entry.nameHash != testHash)
@@ -366,7 +366,7 @@ void RMDPArchive::loadHeaderV8(Common::ReadStream *bin, Common::EndianReadStream
 	_fileEntries.resize(numFiles);
 
 	for (auto &entry : _folderEntries)
-		entry = this->readFolder(bin, end, nameSize);
+		entry = readFolder(bin, end, nameSize);
 	
 	// TO-DO: Fill in _fileEntries array
 }

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -87,7 +87,7 @@ std::vector<uint32_t> RMDPArchive::getPathHashes(std::string &path) const {
 	return pathHashes;
 }
 
-std::optional<RMDPArchive::FolderEntry> RMDPArchive::findDirectory(std::vector<uint32_t> &pathHashes) const {
+std::optional<RMDPArchive::FolderEntry> RMDPArchive::findDirectory(const std::vector<uint32_t> &pathHashes) const {
 	FolderEntry folder = _folderEntries.front();
 	if (pathHashes.empty()) return folder;
 

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -178,30 +178,6 @@ private:
 	};
 
 	/*!
-	 * An utility function that checks whether given folder's
-	 * nextNeighbourFolder field is pointing to an actual address 
-	 * or not. Depending on a header version, this check might
-	 * slightly vary. 
-	 */
-	bool hasNextFolder(FolderEntry &folder) const;
-
-	/*!
-	 * An utility function that checks whether given folder's
-	 * prevFolder field is pointing to an actual address 
-	 * or not. Depending on a header version, this check might
-	 * slightly vary. 
-	 */
-	bool hasPrevFolder(FolderEntry &folder) const;
-
-	/*!
-	 * A helper function that navigates through _folderEntries under
-	 * path gives as a string.
-	 *
-	 * \return folder entry, if it exists under giver path
-	 */
-	std::optional<FolderEntry> findDirectory(std::string &path) const;
-
-	/*!
 	 * A helper function that navigates through _folderEntries under
 	 * path given as an array of hashes.
 	 *

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -183,7 +183,7 @@ private:
 	 *
 	 * \return folder entry, if it exists under giver path
 	 */
-	std::optional<FolderEntry> findDirectory(std::vector<uint32_t> &pathHashes) const;
+	std::optional<FolderEntry> findDirectory(const std::vector<uint32_t> &pathHashes) const;
 
 	/*!
 	 * A helper functon that find a file in a given folder by

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -21,7 +21,6 @@
 #ifndef AWE_RMDPARCHIVE_H
 #define AWE_RMDPARCHIVE_H
 
-#include <sstream>
 #include <vector>
 #include <memory>
 #include <optional>
@@ -114,6 +113,7 @@ private:
 	 * Load header version 2 used by Alan Wake
 	 *
 	 * \param bin the stream from which to load the header
+	 * \param end stream wrapper with fixed endianness
 	 */
 	void loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream end);
 
@@ -121,6 +121,7 @@ private:
 	 * Load header version 7 used by Alan Wakes American Nightmare
 	 *
 	 * \param bin the stream from which to load the header
+	 * \param end stream wrapper with fixed endianness
 	 */
 	void loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream end);
 
@@ -128,12 +129,15 @@ private:
 	 * Load header version 8 used by Quantum Break
 	 *
 	 * \param bin the stream from which to load the header
+	 * \param end stream wrapper with fixed endianness
 	 */
 	void loadHeaderV8(Common::ReadStream *bin, Common::EndianReadStream end);
 
 	/*!
 	 * An utility function to read a file/folder name from an offset
 	 * with known name size.
+	 *
+	 * \param bin the stream from which to load the name
 	 */
 	std::string readEntryName(Common::ReadStream *bin, uint32_t offset, uint32_t nameSize);
 	
@@ -167,12 +171,6 @@ private:
 		uint64_t offset, size;
 	};
 
-	bool _pathPrefix;
-	bool _littleEndian;
-
-	std::vector<FolderEntry> _folderEntries;
-	std::vector<FileEntry> _fileEntries;
-
 	/*!
 	 * A helper function that navigates through _folderEntries under
 	 * given path.
@@ -184,8 +182,8 @@ private:
 	/*!
 	 * A helper function that fills in known FolderEntry fields.
 	 * 
-	 * \param readUint32 A ReadStream member function to read
-	 * 32-bit unsigned integers with appropriate endianness
+	 * \param bin the stream from which to load the fields
+	 * \param end stream wrapper with fixed endianness
 	 * \param nameSize Max name size in bytes, obtained from
 	 * earlier file headers.
 	 */
@@ -194,10 +192,8 @@ private:
 	/*!
 	 * A helper function that fills in known FileEntry fields.
 	 * 
-	 * \param readUint32 A ReadStream member function to read
-	 * 32-bit unsigned integers with appropriate endianness
-	 * \param readUint64 A ReadStream member function to read
-	 * 64-bit unsigned integers with appropriate endianness
+	 * \param bin the stream from which to load the fields
+	 * \param end stream wrapper with fixed endianness
 	 * \param nameSize Max name size in bytes, obtained from
 	 * earlier file headers.
 	 */
@@ -208,6 +204,12 @@ private:
 	 * its name hash value.
 	 */
 	std::optional<FileEntry> findFile(const FolderEntry &folder, const uint32_t nameHash) const;
+
+	bool _pathPrefix;
+	bool _littleEndian;
+
+	std::vector<FolderEntry> _folderEntries;
+	std::vector<FileEntry> _fileEntries;
 
 	std::unique_ptr<Common::ReadStream> _rmdp;
 };

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -137,14 +137,6 @@ private:
 	std::string readEntryName(Common::ReadStream *bin, uint32_t offset, uint32_t nameSize);
 	
 	/*!
-	 * An utility function that normalizes file path by:
-	 * - replacing \ with /
-	 * - adding prefix when needed
-	 * - lowercasing the path
-	 */
-	std::string getNormalizedPath(const std::string &path) const;
-	
-	/*!
 	 * Structure describing a folder entry of the loaded bin/rmdp archive
 	 * structure. Has name hash for faster comparison and indices to the next
 	 * lower folder, the next neighbour folder and the next folder inside.

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -142,7 +142,7 @@ private:
 	 * - adding prefix when needed
 	 * - lowercasing the path
 	 */
-	std::stringstream getNormalizedPath(const std::string &path) const;
+	std::string getNormalizedPath(const std::string &path) const;
 	
 	/*!
 	 * Structure describing a folder entry of the loaded bin/rmdp archive
@@ -186,7 +186,8 @@ private:
 	 *
 	 * \return folder entry, if it exists under giver path
 	 */
-	std::optional<FolderEntry> findDirectory(std::stringstream &path) const;
+	std::optional<FolderEntry> findDirectory(std::string &path) const;
+
 	/*!
 	 * A helper function that fills in known FolderEntry fields.
 	 * 
@@ -196,6 +197,7 @@ private:
 	 * earlier file headers.
 	 */
 	FolderEntry readFolder(Common::ReadStream *bin, uint32_t (Common::ReadStream::*readUint32) (), uint32_t nameSize);
+
 	/*!
 	 * A helper function that fills in known FileEntry fields.
 	 * 
@@ -207,6 +209,7 @@ private:
 	 * earlier file headers.
 	 */
 	FileEntry readFile(Common::ReadStream *bin, uint32_t (Common::ReadStream::*readUint32) (), uint64_t (Common::ReadStream::*readUint64) (), uint32_t nameSize);
+
 	/*!
 	 * A helper functon that find a file in a given folder by
 	 * its name hash value.
@@ -214,8 +217,6 @@ private:
 	std::optional<FileEntry> findFile(const FolderEntry &folder, const uint32_t nameHash) const;
 
 	std::unique_ptr<Common::ReadStream> _rmdp;
-
-	static const uint32_t NO_ENTRY = 0xFFFFFFFF;
 };
 
 } // End of namespace AWE

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -115,7 +115,7 @@ private:
 	 * \param bin the stream from which to load the header
 	 * \param end stream wrapper with fixed endianness
 	 */
-	void loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream end);
+	void loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream &end);
 
 	/*!
 	 * Load header version 7 used by Alan Wakes American Nightmare
@@ -123,7 +123,7 @@ private:
 	 * \param bin the stream from which to load the header
 	 * \param end stream wrapper with fixed endianness
 	 */
-	void loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream end);
+	void loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream &end);
 
 	/*!
 	 * Load header version 8 used by Quantum Break
@@ -131,7 +131,7 @@ private:
 	 * \param bin the stream from which to load the header
 	 * \param end stream wrapper with fixed endianness
 	 */
-	void loadHeaderV8(Common::ReadStream *bin, Common::EndianReadStream end);
+	void loadHeaderV8(Common::ReadStream *bin, Common::EndianReadStream &end);
 
 	/*!
 	 * An utility function to read a file/folder name from an offset
@@ -140,6 +140,12 @@ private:
 	 * \param bin the stream from which to load the name
 	 */
 	std::string readEntryName(Common::ReadStream *bin, uint32_t offset, uint32_t nameSize);
+
+	/*!
+	 * Break down a given path into an array of CRC32 hashes
+	 * for later processing.
+	 */
+	std::vector<uint32_t> getPathHashes(std::string &path) const;
 	
 	/*!
 	 * Structure describing a folder entry of the loaded bin/rmdp archive
@@ -173,11 +179,19 @@ private:
 
 	/*!
 	 * A helper function that navigates through _folderEntries under
-	 * given path.
+	 * path gives as a string.
 	 *
 	 * \return folder entry, if it exists under giver path
 	 */
 	std::optional<FolderEntry> findDirectory(std::string &path) const;
+
+	/*!
+	 * A helper function that navigates through _folderEntries under
+	 * path given as an array of hashes.
+	 *
+	 * \return folder entry, if it exists under giver path
+	 */
+	std::optional<FolderEntry> findDirectory(std::vector<uint32_t> &pathHashes) const;
 
 	/*!
 	 * A helper function that fills in known FolderEntry fields.
@@ -187,7 +201,7 @@ private:
 	 * \param nameSize Max name size in bytes, obtained from
 	 * earlier file headers.
 	 */
-	FolderEntry readFolder(Common::ReadStream *bin, Common::EndianReadStream end, uint32_t nameSize);
+	FolderEntry readFolder(Common::ReadStream *bin, Common::EndianReadStream &end, uint32_t nameSize);
 
 	/*!
 	 * A helper function that fills in known FileEntry fields.
@@ -197,7 +211,7 @@ private:
 	 * \param nameSize Max name size in bytes, obtained from
 	 * earlier file headers.
 	 */
-	FileEntry readFile(Common::ReadStream *bin, Common::EndianReadStream end, uint32_t nameSize);
+	FileEntry readFile(Common::ReadStream *bin, Common::EndianReadStream &end, uint32_t nameSize);
 
 	/*!
 	 * A helper functon that find a file in a given folder by

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -204,16 +204,6 @@ private:
 	FolderEntry readFolder(Common::ReadStream *bin, Common::EndianReadStream &end, uint32_t nameSize);
 
 	/*!
-	 * A helper function that fills in known FileEntry fields.
-	 * 
-	 * \param bin the stream from which to load the fields
-	 * \param end stream wrapper with fixed endianness
-	 * \param nameSize Max name size in bytes, obtained from
-	 * earlier file headers.
-	 */
-	FileEntry readFile(Common::ReadStream *bin, Common::EndianReadStream &end, uint32_t nameSize);
-
-	/*!
 	 * A helper functon that find a file in a given folder by
 	 * its name hash value.
 	 */

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -27,6 +27,7 @@
 #include <optional>
 
 #include "archive.h"
+#include "src/common/endianreadstream.h"
 
 namespace AWE {
 
@@ -114,21 +115,21 @@ private:
 	 *
 	 * \param bin the stream from which to load the header
 	 */
-	void loadHeaderV2(Common::ReadStream *bin);
+	void loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream end);
 
 	/*!
 	 * Load header version 7 used by Alan Wakes American Nightmare
 	 *
 	 * \param bin the stream from which to load the header
 	 */
-	void loadHeaderV7(Common::ReadStream *bin);
+	void loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream end);
 
 	/*!
 	 * Load header version 8 used by Quantum Break
 	 *
 	 * \param bin the stream from which to load the header
 	 */
-	void loadHeaderV8(Common::ReadStream *bin);
+	void loadHeaderV8(Common::ReadStream *bin, Common::EndianReadStream end);
 
 	/*!
 	 * An utility function to read a file/folder name from an offset
@@ -188,7 +189,7 @@ private:
 	 * \param nameSize Max name size in bytes, obtained from
 	 * earlier file headers.
 	 */
-	FolderEntry readFolder(Common::ReadStream *bin, uint32_t (Common::ReadStream::*readUint32) (), uint32_t nameSize);
+	FolderEntry readFolder(Common::ReadStream *bin, Common::EndianReadStream end, uint32_t nameSize);
 
 	/*!
 	 * A helper function that fills in known FileEntry fields.
@@ -200,7 +201,7 @@ private:
 	 * \param nameSize Max name size in bytes, obtained from
 	 * earlier file headers.
 	 */
-	FileEntry readFile(Common::ReadStream *bin, uint32_t (Common::ReadStream::*readUint32) (), uint64_t (Common::ReadStream::*readUint64) (), uint32_t nameSize);
+	FileEntry readFile(Common::ReadStream *bin, Common::EndianReadStream end, uint32_t nameSize);
 
 	/*!
 	 * A helper functon that find a file in a given folder by

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -156,9 +156,9 @@ private:
 		std::string name;
 		uint32_t nameHash;
 		uint32_t nextLowerFolder;
-		uint32_t nextNeighbourFolder;
+		uint64_t nextNeighbourFolder = 0;
 		uint32_t nextFile;
-		uint32_t prevFolder;
+		uint64_t prevFolder = 0;
 	};
 
 	/*!
@@ -178,6 +178,22 @@ private:
 	};
 
 	/*!
+	 * An utility function that checks whether given folder's
+	 * nextNeighbourFolder field is pointing to an actual address 
+	 * or not. Depending on a header version, this check might
+	 * slightly vary. 
+	 */
+	bool hasNextFolder(FolderEntry &folder) const;
+
+	/*!
+	 * An utility function that checks whether given folder's
+	 * prevFolder field is pointing to an actual address 
+	 * or not. Depending on a header version, this check might
+	 * slightly vary. 
+	 */
+	bool hasPrevFolder(FolderEntry &folder) const;
+
+	/*!
 	 * A helper function that navigates through _folderEntries under
 	 * path gives as a string.
 	 *
@@ -194,16 +210,6 @@ private:
 	std::optional<FolderEntry> findDirectory(std::vector<uint32_t> &pathHashes) const;
 
 	/*!
-	 * A helper function that fills in known FolderEntry fields.
-	 * 
-	 * \param bin the stream from which to load the fields
-	 * \param end stream wrapper with fixed endianness
-	 * \param nameSize Max name size in bytes, obtained from
-	 * earlier file headers.
-	 */
-	FolderEntry readFolder(Common::ReadStream *bin, Common::EndianReadStream &end, uint32_t nameSize);
-
-	/*!
 	 * A helper functon that find a file in a given folder by
 	 * its name hash value.
 	 */
@@ -211,6 +217,7 @@ private:
 
 	bool _pathPrefix;
 	bool _littleEndian;
+	uint32_t _version;
 
 	std::vector<FolderEntry> _folderEntries;
 	std::vector<FileEntry> _fileEntries;

--- a/src/common/endianreadstream.cpp
+++ b/src/common/endianreadstream.cpp
@@ -18,10 +18,11 @@
  * along with OpenAWE. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "endianreadstream.h"
+#include "src/common/endianreadstream.h"
 #include "src/common/readstream.h"
 
 namespace Common {
+
 EndianReadStream::EndianReadStream(ReadStream *parentStream, bool bigEndian) {
     _bigEndian = bigEndian;
     _parentStream = parentStream;

--- a/src/common/endianreadstream.cpp
+++ b/src/common/endianreadstream.cpp
@@ -1,0 +1,43 @@
+/* OpenAWE - A reimplementation of Remedys Alan Wake Engine
+ *
+ * OpenAWE is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * OpenAWE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * OpenAWE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenAWE. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "endianreadstream.h"
+#include "src/common/readstream.h"
+
+namespace Common {
+EndianReadStream::EndianReadStream(ReadStream *parentStream, bool bigEndian) {
+    _bigEndian = bigEndian;
+    _parentStream = parentStream;
+};
+
+EndianReadStream::~EndianReadStream() = default;
+
+uint16_t EndianReadStream::readUint16() {
+    return _bigEndian ? _parentStream->readUint16BE() : _parentStream->readUint16LE();
+}
+
+uint32_t EndianReadStream::readUint32() {
+    return _bigEndian ? _parentStream->readUint32BE() : _parentStream->readUint32LE();
+}
+
+uint64_t EndianReadStream::readUint64() {
+    return _bigEndian ? _parentStream->readUint64BE() : _parentStream->readUint64LE();
+}
+}; // End of namespace Common

--- a/src/common/endianreadstream.h
+++ b/src/common/endianreadstream.h
@@ -27,33 +27,38 @@
 namespace Common {
 
 class EndianReadStream {
-private:
-	bool _bigEndian;
-	ReadStream *_parentStream;
-
 public:
+	/*
+	 * Create a ReadStream wrapper that has a predefined
+	 * endianness.
+	 */
 	EndianReadStream(ReadStream *parentStream, bool bigEndian);
 
 	virtual ~EndianReadStream();
 
-    /*!
+	/*!
 	 * Read a 16 bit unsigned int
 	 * \return the 16bit value
 	 */
 	uint16_t readUint16();
 
-    /*!
+	/*!
 	 * Read a 32 bit unsigned int
 	 * \return the 32bit value
 	 */
 	uint32_t readUint32();
 
-    /*!
+	/*!
 	 * Read a 64 bit unsigned int
 	 * \return the 64bit value
 	 */
 	uint64_t readUint64();
+
+private:
+	bool _bigEndian;
+	ReadStream *_parentStream;
 };
+
 } // End of namespace Common
 
 #endif //SRC_COMMON_ENDIANREADSTREAMS_H

--- a/src/common/endianreadstream.h
+++ b/src/common/endianreadstream.h
@@ -28,7 +28,7 @@ namespace Common {
 
 class EndianReadStream {
 public:
-	/*
+	/*!
 	 * Create a ReadStream wrapper that has a predefined
 	 * endianness.
 	 */

--- a/src/common/endianreadstream.h
+++ b/src/common/endianreadstream.h
@@ -1,0 +1,59 @@
+/* OpenAWE - A reimplementation of Remedys Alan Wake Engine
+ *
+ * OpenAWE is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * OpenAWE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * OpenAWE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenAWE. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRC_COMMON_ENDIANREADSTREAMS_H
+#define SRC_COMMON_ENDIANREADSTREAMS_H
+
+#include "src/common/readstream.h"
+#include "src/common/types.h"
+
+namespace Common {
+
+class EndianReadStream {
+private:
+	bool _bigEndian;
+	ReadStream *_parentStream;
+
+public:
+	EndianReadStream(ReadStream *parentStream, bool bigEndian);
+
+	virtual ~EndianReadStream();
+
+    /*!
+	 * Read a 16 bit unsigned int
+	 * \return the 16bit value
+	 */
+	uint16_t readUint16();
+
+    /*!
+	 * Read a 32 bit unsigned int
+	 * \return the 32bit value
+	 */
+	uint32_t readUint32();
+
+    /*!
+	 * Read a 64 bit unsigned int
+	 * \return the 64bit value
+	 */
+	uint64_t readUint64();
+};
+} // End of namespace Common
+
+#endif //SRC_COMMON_ENDIANREADSTREAMS_H

--- a/src/common/strutil.cpp
+++ b/src/common/strutil.cpp
@@ -63,4 +63,11 @@ std::vector<std::string> split(const std::string &str, const std::regex &split) 
 	return result;
 }
 
+std::string getNormalizedPath(const std::string &path) {
+	std::string lower = Common::toLower(path);
+	uint64_t pos = std::string::npos;
+	while ((pos = lower.find("\\")) != std::string::npos) lower.replace(pos, 1, "/", 1);
+	return lower;
+}
+
 }

--- a/src/common/strutil.cpp
+++ b/src/common/strutil.cpp
@@ -48,7 +48,7 @@ std::string toUpper(std::string str) {
 }
 
 bool contains(const std::string &str, const std::string &s) {
-	return std::regex_match(str, std::regex(".*" + s + ".*"));
+	return str.find(s) != std::string::npos;
 }
 
 std::vector<std::string> split(const std::string &str, const std::regex &split) {

--- a/src/common/strutil.h
+++ b/src/common/strutil.h
@@ -58,11 +58,11 @@ bool contains(const std::string &str, const std::string &s);
 std::vector<std::string> split(const std::string &str, const std::regex &split);
 
 /*!
-	 * An utility function that normalizes file path by:
-	 * - replacing \ with /
-	 * - lowercasing the path
-	 */
-	std::string getNormalizedPath(const std::string &path);
+ * An utility function that normalizes file path by:
+ * - replacing \ with /
+ * - lowercasing the path
+ */
+std::string getNormalizedPath(const std::string &path);
 }
 
 #endif //AWE_STRUTIL_H

--- a/src/common/strutil.h
+++ b/src/common/strutil.h
@@ -56,13 +56,6 @@ bool contains(const std::string &str, const std::string &s);
  * \return a vector of split strings
  */
 std::vector<std::string> split(const std::string &str, const std::regex &split);
-
-/*!
- * An utility function that normalizes file path by:
- * - replacing \ with /
- * - lowercasing the path
- */
-std::string getNormalizedPath(const std::string &path);
 }
 
 #endif //AWE_STRUTIL_H

--- a/src/common/strutil.h
+++ b/src/common/strutil.h
@@ -57,6 +57,12 @@ bool contains(const std::string &str, const std::string &s);
  */
 std::vector<std::string> split(const std::string &str, const std::regex &split);
 
+/*!
+	 * An utility function that normalizes file path by:
+	 * - replacing \ with /
+	 * - lowercasing the path
+	 */
+	std::string getNormalizedPath(const std::string &path);
 }
 
 #endif //AWE_STRUTIL_H


### PR DESCRIPTION
This pull request is meant to (more or less) resolve #16. Most of the changes are contained within RMDPArchive class. Multiple new helper functions were created in order to minimize repeating code. `loadHeaderVX()` functions have been edited to use function pointers for reading variables to prevent typos. Regexes were replaced by simpler `std::string::find()` and `std::string::replace()` functions since they were needed for simple substring search/substitution.
Note: I haven't been able to test those changes properly as I currently don't have AW installed. 