### PR TITLE
Patch CMakeLists to better support Linux distributions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,8 @@ endif ()
 link_libraries(
         ${CMAKE_THREAD_LIBS_INIT}
 
-        glm::glm
+	$<TARGET_NAME_IF_EXISTS:glm::glm>
+	$<TARGET_NAME_IF_EXISTS:glm>
         fmt::fmt
         CLI11::CLI11
 


### PR DESCRIPTION
This PR is meant to patch CMakeLists.txt to allow building for more Linux distributions (like Arch Linux).