### PR TITLE
Add Probe class

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -123,28 +123,29 @@ void Game::init() {
 	}
 
 	if (identifiers.empty())
-		throw Common::Exception("No .rmdp files found in the set data path.");
+		throw CreateException("No .rmdp files found in the set data path.");
 
 	GameEngine engine;
 
 	// Launch probe to see what game we are dealing with
 	Probe probe = Probe();
-	unsigned char probeResult = probe.performProbe();
+	ProbeResult probeResult = probe.performProbe();
 	switch (probeResult) {
 		case kResultAlanWake:
 			spdlog::info("Initializing Alan Wake...");
 			engine = kAlanWake;
 			break;
-		case kResultNightmare:
+		case kResultAmericanNightmare:
 			spdlog::info("Initializing Alan Wake's American Nightmare...");
 			engine = kAlanWakesAmericanNightmare;
 			break;
 		case kResultQuantumBreak:
+			throw CreateException("Quantum Break is not yet supported by OpenAWE.");
 		case kResultAlanWakeRemastered:
-			throw Common::Exception("This game is not yet supported by OpenAWE.");
+			throw CreateException("Alan Wake Remastered is not yet supported by OpenAWE.");
 		case kResultUnknown:
 		default:
-			throw Common::Exception("Unknown game data was supplied.");
+			throw CreateException("Unknown game data was supplied.");
 	}
 
 	// Check if the resources have packmeta files and load them and if not load streamed resources

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -18,6 +18,8 @@
  * along with OpenAWE. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <bitset>
+
 #include <spdlog/spdlog.h>
 
 #include "src/awe/resman.h"
@@ -29,18 +31,17 @@ Probe::Probe() {}
 
 ProbeResult Probe::performProbe() {
 	spdlog::info("Probing archives...");
-	uint8_t allChecks = 
-					checkAlanWake() |
-					checkAmericanNightmare() |
-					checkQuantumBreak() |
-					checkAlanWakeRemastered();
-	if ((allChecks & (allChecks - 1)) != 0) // Zero or more that one successful checks...
-		if (allChecks == kResultUnknown)
-			return kResultUnknown;
-		else
-			throw CreateException("Ambiguous archives: probe failed to recognise a certain game");
+	std::bitset<8> allChecks = 
+		checkAlanWake() |
+		checkAmericanNightmare() |
+		checkQuantumBreak() |
+		checkAlanWakeRemastered();
+	if (allChecks.none())
+		return kResultUnknown;
+	else if (allChecks.count() == 1)
+		return static_cast<ProbeResult>(allChecks.to_ulong());
 	else
-	 	return static_cast<ProbeResult>(allChecks);
+		throw CreateException("Ambiguous archives: probe failed to recognise a certain game");	 	
 }
 
 ProbeResult Probe::checkAlanWake() {
@@ -49,14 +50,17 @@ ProbeResult Probe::checkAlanWake() {
 	// check for Stucky's texture variation
 	bool hasStuckyVar02 = ResMan.hasDirectory("textures/characters/stucky_var02");
 	// check for sponsored ads
-	bool hasVerizonCellPhone = ResMan.hasResource("textures/objects/items/misc/cellphone_verizon_n.tex") &&
-							   ResMan.hasResource("textures/objects/items/misc/cellphone_verizon.tex");
-	bool hasEnergizerBatteries = ResMan.hasResource("textures/objects/items/lightsources/energizer_flashlight_test.tex") &&
-								 ResMan.hasResource("textures/objects/items/lightsources/energizer_lithium.tex") &&
-								 ResMan.hasResource("textures/objects/items/lightsources/energizer_max.tex");
+	bool hasVerizonCellPhone = 
+		ResMan.hasResource("textures/objects/items/misc/cellphone_verizon_n.tex") &&
+		ResMan.hasResource("textures/objects/items/misc/cellphone_verizon.tex");
+	bool hasEnergizerBatteries = 
+		ResMan.hasResource("textures/objects/items/lightsources/energizer_flashlight_test.tex") &&
+		ResMan.hasResource("textures/objects/items/lightsources/energizer_lithium.tex") &&
+		ResMan.hasResource("textures/objects/items/lightsources/energizer_max.tex");
 	// check for "gameplay_example" meshes
-	bool hasGameplayExample = ResMan.hasResource("objects/backdrop/gameplay_example_0_0.binmsh") &&
-							  ResMan.hasResource("objects/backdrop/gameplay_example_3_3.binmsh");
+	bool hasGameplayExample = 
+		ResMan.hasResource("objects/backdrop/gameplay_example_0_0.binmsh") &&
+		ResMan.hasResource("objects/backdrop/gameplay_example_3_3.binmsh");
 	// check for test breakable table mesh
 	bool hasBreakableTableTest = ResMan.hasResource("objects/test/breakabletable_mesh.binmsh");
 	// check for Arial font
@@ -77,36 +81,41 @@ ProbeResult Probe::checkAlanWakeRemastered() {
 	// check for new deerfest parade truck textures
 	bool hasParadefloat = ResMan.hasDirectory("textures/objects/vehicles/new/paradefloat/paradefloat");
 	// check for Rose's trailer items
-	bool hasRosesTrailer = ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosestrailerpropsd3t.tex") &&
-						   ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosepillow_d3t.tex") &&
-						   ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosebedsheet_d3t.tex");
+	bool hasRosesTrailer = 
+		ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosestrailerpropsd3t.tex") &&
+		ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosepillow_d3t.tex") &&
+		ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosebedsheet_d3t.tex");
 	// check for complex Andersson's farm
-	bool hasComplexAnderssonsFarm = ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/barnandersson") &&
-									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/mainbuilding") &&
-									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/rockstage") &&
-									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/threshingandersson") &&
-									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/windmillandersson");
+	bool hasComplexAnderssonsFarm = 
+		ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/barnandersson") &&
+		ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/mainbuilding") &&
+		ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/rockstage") &&
+		ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/threshingandersson") &&
+		ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/windmillandersson");
 	// check for Zane's book covers
 	bool hasZaneBookCovers = ResMan.hasResource("textures/objects/props/special/zane_books_covers.tex");
 	// check for "missing" posters textures
-	bool hasMissingPosters = ResMan.hasResource("textures/objects/props/special/missingposter_contestwinner_s.tex") &&
-							 ResMan.hasResource("textures/objects/props/special/missing_campers_s.tex");
+	bool hasMissingPosters = 
+		ResMan.hasResource("textures/objects/props/special/missingposter_contestwinner_s.tex") &&
+		ResMan.hasResource("textures/objects/props/special/missing_campers_s.tex");
 	// check for Alan Wake's sunglasses texture
 	bool hasAlanWakeSunglasses = ResMan.hasResource("textures/objects/items/misc/alanwakesunglasses_s.tex");
 	// check for intentional easter eggs
-	bool hasEasterEggs = ResMan.hasResource("objects/props/special/easter_eggs_ahma_beer.binmsh") &&
-						 ResMan.hasResource("objects/props/special/easter_eggs_coffee_world.binmsh") &&
-						 ResMan.hasResource("objects/props/special/easter_eggs_fbc_letter.binmsh") &&
-						 ResMan.hasResource("objects/props/special/easter_eggs_jim_figamore.binmsh") &&
-						 ResMan.hasResource("objects/props/special/easter_eggs_kalevala_knights.binmsh") &&
-						 ResMan.hasResource("objects/props/special/easter_eggs_tower_maintenance.binmsh") &&
-						 ResMan.hasResource("objects/props/special/easter_eggs_watery_attractions.binmsh");
+	bool hasEasterEggs = 
+		ResMan.hasResource("objects/props/special/easter_eggs_ahma_beer.binmsh") &&
+		ResMan.hasResource("objects/props/special/easter_eggs_coffee_world.binmsh") &&
+		ResMan.hasResource("objects/props/special/easter_eggs_fbc_letter.binmsh") &&
+		ResMan.hasResource("objects/props/special/easter_eggs_jim_figamore.binmsh") &&
+		ResMan.hasResource("objects/props/special/easter_eggs_kalevala_knights.binmsh") &&
+		ResMan.hasResource("objects/props/special/easter_eggs_tower_maintenance.binmsh") &&
+		ResMan.hasResource("objects/props/special/easter_eggs_watery_attractions.binmsh");
 	// check for GDC '09 cinematic animations ?
-	bool hasGDC09Animations = ResMan.hasResource("animations/male/alanwake/cinematic_gdc09_1100_wake.binhkx") &&
-							  ResMan.hasResource("animations/male/barrywheeler/cinematic_gdc09_1100_barry.binhkx") &&
-							  ResMan.hasResource("animations/male/lee/cinematic_gdc09_1300b_lee.binhkx") &&
-							  ResMan.hasResource("animations/male/rusty/cinematic_gdc09_1300b_rusty.binhkx") &&
-							  ResMan.hasResource("animations/female/alice/cinematic_gdc09_1050_alice.binhkx");
+	bool hasGDC09Animations = 
+		ResMan.hasResource("animations/male/alanwake/cinematic_gdc09_1100_wake.binhkx") &&
+		ResMan.hasResource("animations/male/barrywheeler/cinematic_gdc09_1100_barry.binhkx") &&
+		ResMan.hasResource("animations/male/lee/cinematic_gdc09_1300b_lee.binhkx") &&
+		ResMan.hasResource("animations/male/rusty/cinematic_gdc09_1300b_rusty.binhkx") &&
+		ResMan.hasResource("animations/female/alice/cinematic_gdc09_1050_alice.binhkx");
 
 	if (hasGDC09Animations && hasAlanWakeSunglasses &&
 		hasComplexAnderssonsFarm && hasEasterEggs &&
@@ -122,38 +131,45 @@ ProbeResult Probe::checkAlanWakeRemastered() {
 
 ProbeResult Probe::checkAmericanNightmare() {
 	// check for game's characters
-	bool hasNightmareCharacters = ResMan.hasResource("objects/characters/alanwake_awns_mesh.binmsh") &&
-								  ResMan.hasResource("objects/characters/female_npc_emma_emmasloan.binmsh") &&
-								  ResMan.hasResource("objects/characters/female_npc_rachel_rachelmeadows.binmsh") &&
-								  ResMan.hasResource("objects/characters/female_npc_serena_serenavaldivia.binmsh") &&
-								  ResMan.hasResource("objects/characters/mr_scratch_mr_scratch.binmsh");
+	bool hasNightmareCharacters = 
+		ResMan.hasResource("objects/characters/alanwake_awns_mesh.binmsh") &&
+		ResMan.hasResource("objects/characters/female_npc_emma_emmasloan.binmsh") &&
+		ResMan.hasResource("objects/characters/female_npc_rachel_rachelmeadows.binmsh") &&
+		ResMan.hasResource("objects/characters/female_npc_serena_serenavaldivia.binmsh") &&
+		ResMan.hasResource("objects/characters/mr_scratch_mr_scratch.binmsh");
 	// check for film festival banner
 	bool hasFilmFestivalBanner = ResMan.hasResource("objects/props/special/film_festival_banner_banner_med.binmsh");
 	// check for first level's sattelite
-	bool hasSatellite = ResMan.hasResource("objects/props/special/level1_misc_satelite.binhvk") &&
-						ResMan.hasResource("objects/props/special/level1_misc_satelite.binmsh");
+	bool hasSatellite = 
+		ResMan.hasResource("objects/props/special/level1_misc_satelite.binhvk") &&
+		ResMan.hasResource("objects/props/special/level1_misc_satelite.binmsh");
 	// check for observatory posters
-	bool hasObservatoryPosters = ResMan.hasResource("objects/props/special/observatory_posters_poster_01.binmsh") &&
-								 ResMan.hasResource("objects/props/special/observatory_posters_poster_02.binmsh");
+	bool hasObservatoryPosters = 
+		ResMan.hasResource("objects/props/special/observatory_posters_poster_01.binmsh") &&
+		ResMan.hasResource("objects/props/special/observatory_posters_poster_02.binmsh");
 	// check for leftover prototype buttons
-	bool hasPrototypeButtons = ResMan.hasResource("objects/prototype/test_numbers_green_button.binmsh") &&
-							   ResMan.hasResource("objects/prototype/test_numbers_red_button.binmsh");
+	bool hasPrototypeButtons = 
+		ResMan.hasResource("objects/prototype/test_numbers_green_button.binmsh") &&
+		ResMan.hasResource("objects/prototype/test_numbers_red_button.binmsh");
 	// check for game's main level structures
-	bool hasNightmareComplexes = ResMan.hasDirectory("objects/structures/complexes/driveintheater") &&
-								 ResMan.hasDirectory("objects/structures/complexes/observatory") &&
-								 ResMan.hasDirectory("objects/structures/complexes/reststop");
+	bool hasNightmareComplexes = 
+		ResMan.hasDirectory("objects/structures/complexes/driveintheater") &&
+		ResMan.hasDirectory("objects/structures/complexes/observatory") &&
+		ResMan.hasDirectory("objects/structures/complexes/reststop");
 	// check for Nightmare specific music
-	bool hasNightmareMusic = ResMan.hasResource("sounds/music/licensed/club_foot_kasabian.fsb") &&
-							 ResMan.hasResource("sounds/music/potf/potf_balance_slays_the_demon_game_edit.fsb") &&
-							 ResMan.hasResource("sounds/music/potf/potf_psycho_game_edit.fsb") &&
-							 ResMan.hasResource("sounds/music/potf/radio_show_03_music.fsb");
+	bool hasNightmareMusic = 
+		ResMan.hasResource("sounds/music/licensed/club_foot_kasabian.fsb") &&
+		ResMan.hasResource("sounds/music/potf/potf_balance_slays_the_demon_game_edit.fsb") &&
+		ResMan.hasResource("sounds/music/potf/potf_psycho_game_edit.fsb") &&
+		ResMan.hasResource("sounds/music/potf/radio_show_03_music.fsb");
 	// check for arcade mode game worlds
-	bool hasArcadeWorlds = ResMan.hasDirectory("worlds/gameworld/levels/arcade6_rim") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/arcade5_rim") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/arcade4_rim") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/arcade3_rim") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/arcade2_rim") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/arcade1_rim");
+	bool hasArcadeWorlds = 
+		ResMan.hasDirectory("worlds/gameworld/levels/arcade6_rim") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/arcade5_rim") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/arcade4_rim") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/arcade3_rim") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/arcade2_rim") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/arcade1_rim");
 	
 	if (hasArcadeWorlds && hasFilmFestivalBanner &&
 		hasNightmareCharacters && hasNightmareComplexes &&
@@ -169,32 +185,36 @@ ProbeResult Probe::checkAmericanNightmare() {
 
 ProbeResult Probe::checkQuantumBreak() {
 	// check for Microsoft product placement
-	bool hasMicrosoftProducts = ResMan.hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_p_9ddbe72b.aaa") &&
-								ResMan.hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_pro_mesh_000.nmb") &&
-								ResMan.hasResource("objects/ringtail/batch39/microsoft_surface_surface_3_pro_tablet_without_keyboard.binfbx") &&
-								ResMan.hasResource("objects/ringtail/batch45/microsoft_lumia_640.wedmsh");
+	bool hasMicrosoftProducts = 
+		ResMan.hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_p_9ddbe72b.aaa") &&
+		ResMan.hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_pro_mesh_000.nmb") &&
+		ResMan.hasResource("objects/ringtail/batch39/microsoft_surface_surface_3_pro_tablet_without_keyboard.binfbx") &&
+		ResMan.hasResource("objects/ringtail/batch45/microsoft_lumia_640.wedmsh");
 	// check for game levels
-	bool hasQBreakLevels = ResMan.hasDirectory("worlds/gameworld/levels/sofias_island") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/university") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/shipyard") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/secretlab") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/old_riverport") &&
-						   ResMan.hasDirectory("worlds/gameworld/levels/default");
+	bool hasQBreakLevels = 
+		ResMan.hasDirectory("worlds/gameworld/levels/sofias_island") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/university") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/shipyard") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/secretlab") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/old_riverport") &&
+		ResMan.hasDirectory("worlds/gameworld/levels/default");
 	// check for leftover whiteboxing prototype files
 	bool hasQBreakPrototype = ResMan.hasDirectory("textures/whiteboxing_temp/monarch_hq/lods");
 	// check for time machine textures
 	bool hasTimeMachine = ResMan.hasDirectory("textures/time_machine");
 	// check for Nissan Leaf product placement
-	bool hasNissanLeaf = ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_logos.wedmsh") &&
-						 ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_monarch.binhvk") &&
-						 ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_taxi.binhvk");
+	bool hasNissanLeaf = 
+		ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_logos.wedmsh") &&
+		ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_monarch.binhvk") &&
+		ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_taxi.binhvk");
 	// check for Monarch HQ building
 	bool hasMonarchHQ = ResMan.hasDirectory("objects/structures/monarch_hq");
 	// check for games characters
-	bool hasQBreakCharacters = ResMan.hasDirectory("textures/characters/wiljoy") &&
-							   ResMan.hasDirectory("textures/characters/jacjoy") &&
-							   ResMan.hasDirectory("textures/characters/liabur") &&
-							   ResMan.hasDirectory("textures/characters/nicmar");
+	bool hasQBreakCharacters = 
+		ResMan.hasDirectory("textures/characters/wiljoy") &&
+		ResMan.hasDirectory("textures/characters/jacjoy") &&
+		ResMan.hasDirectory("textures/characters/liabur") &&
+		ResMan.hasDirectory("textures/characters/nicmar");
 	
 	if (hasQBreakCharacters && hasQBreakPrototype &&
 		hasQBreakLevels && hasMicrosoftProducts &&

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -1,0 +1,204 @@
+/* OpenAWE - A reimplementation of Remedys Alan Wake Engine
+ *
+ * OpenAWE is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * OpenAWE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * OpenAWE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenAWE. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <spdlog/spdlog.h>
+
+#include "src/awe/rmdparchive.h"
+#include "probe.h"
+
+Probe::Probe() {
+	_resources = &ResMan;
+}
+
+unsigned char Probe::performProbe() {
+	spdlog::info("Probing archives...");
+	uint8_t allChecks = checkAlanWake() |
+						checkNightmare() |
+						checkQuantumBreak() |
+						checkAlanWakeRemastered();
+	if ((allChecks & (allChecks - 1)) != 0) // More that one successful check...
+		return kResultUnknown;
+	else
+	 	return allChecks;
+}
+
+ProbeResult Probe::checkAlanWake() {
+	// check if old Alan Wake's textures are present in files
+	bool hasAlanWake2008 = _resources->hasDirectory("textures/characters/alanwake_2008");
+	// check for Stucky's texture variation
+	bool hasStuckyVar02 = _resources->hasDirectory("textures/characters/stucky_var02");
+	// check for sponsored ads
+	bool hasVerizonCellPhone = _resources->hasResource("textures/objects/items/misc/cellphone_verizon_n.tex") &&
+							   _resources->hasResource("textures/objects/items/misc/cellphone_verizon.tex");
+	bool hasEnergizerBatteries = _resources->hasResource("textures/objects/items/lightsources/energizer_flashlight_test.tex") &&
+								 _resources->hasResource("textures/objects/items/lightsources/energizer_lithium.tex") &&
+								 _resources->hasResource("textures/objects/items/lightsources/energizer_max.tex");
+	// check for "gameplay_example" meshes
+	bool hasGameplayExample = _resources->hasResource("objects/backdrop/gameplay_example_0_0.binmsh") &&
+							  _resources->hasResource("objects/backdrop/gameplay_example_3_3.binmsh");
+	// check for test breakable table mesh
+	bool hasBreakableTableTest = _resources->hasResource("objects/test/breakabletable_mesh.binmsh");
+	// check for Arial font
+	bool hasArial = _resources->hasResource("fonts/Arial.binfnt");
+
+	if (hasArial && hasAlanWake2008 && hasBreakableTableTest &&
+		hasEnergizerBatteries && hasGameplayExample &&
+		hasStuckyVar02 && hasVerizonCellPhone) {
+		spdlog::debug("Looks like Alan Wake!");
+		return kResultAlanWake;
+	} else {
+		spdlog::debug("Doesn't look like Alan Wake...");
+		return kResultUnknown;
+	}
+}
+
+ProbeResult Probe::checkAlanWakeRemastered() {
+	// check for new deerfest parade truck textures
+	bool hasParadefloat = _resources->hasDirectory("textures/objects/vehicles/new/paradefloat/paradefloat");
+	// check for Rose's trailer items
+	bool hasRosesTrailer = _resources->hasResource("textures/objects/structures/complexes/trailerpark/rosestrailerpropsd3t.tex") &&
+						   _resources->hasResource("textures/objects/structures/complexes/trailerpark/rosepillow_d3t.tex") &&
+						   _resources->hasResource("textures/objects/structures/complexes/trailerpark/rosebedsheet_d3t.tex");
+	// check for complex Andersson's farm
+	bool hasComplexAnderssonsFarm = _resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/barnandersson") &&
+									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/mainbuilding") &&
+									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/rockstage") &&
+									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/threshingandersson") &&
+									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/windmillandersson");
+	// check for Zane's book covers
+	bool hasZaneBookCovers = _resources->hasResource("textures/objects/props/special/zane_books_covers.tex");
+	// check for "missing" posters textures
+	bool hasMissingPosters = _resources->hasResource("textures/objects/props/special/missingposter_contestwinner_s.tex") &&
+							 _resources->hasResource("textures/objects/props/special/missing_campers_s.tex");
+	// check for Alan Wake's sunglasses texture
+	bool hasAlanWakeSunglasses = _resources->hasResource("textures/objects/items/misc/alanwakesunglasses_s.tex");
+	// check for intentional easter eggs
+	bool hasEasterEggs = _resources->hasResource("objects/props/special/easter_eggs_ahma_beer.binmsh") &&
+						 _resources->hasResource("objects/props/special/easter_eggs_coffee_world.binmsh") &&
+						 _resources->hasResource("objects/props/special/easter_eggs_fbc_letter.binmsh") &&
+						 _resources->hasResource("objects/props/special/easter_eggs_jim_figamore.binmsh") &&
+						 _resources->hasResource("objects/props/special/easter_eggs_kalevala_knights.binmsh") &&
+						 _resources->hasResource("objects/props/special/easter_eggs_tower_maintenance.binmsh") &&
+						 _resources->hasResource("objects/props/special/easter_eggs_watery_attractions.binmsh");
+	// check for GDC '09 cinematic animations ?
+	bool hasGDC09Animations = _resources->hasResource("animations/male/alanwake/cinematic_gdc09_1100_wake.binhkx") &&
+							  _resources->hasResource("animations/male/barrywheeler/cinematic_gdc09_1100_barry.binhkx") &&
+							  _resources->hasResource("animations/male/lee/cinematic_gdc09_1300b_lee.binhkx") &&
+							  _resources->hasResource("animations/male/rusty/cinematic_gdc09_1300b_rusty.binhkx") &&
+							  _resources->hasResource("animations/female/alice/cinematic_gdc09_1050_alice.binhkx");
+
+	if (hasGDC09Animations && hasAlanWakeSunglasses &&
+		hasComplexAnderssonsFarm && hasEasterEggs &&
+		hasMissingPosters && hasParadefloat &&
+		hasRosesTrailer && hasZaneBookCovers) {
+		spdlog::debug("Looks like Alan Wake Remastered!");
+		return kResultAlanWakeRemastered;
+	} else {
+		spdlog::debug("Doesn't look like Alan Wake Remastered...");
+		return kResultUnknown;
+	}
+}
+
+ProbeResult Probe::checkNightmare() {
+	// check for game's characters
+	bool hasNightmareCharacters = _resources->hasResource("objects/characters/alanwake_awns_mesh.binmsh") &&
+								  _resources->hasResource("objects/characters/female_npc_emma_emmasloan.binmsh") &&
+								  _resources->hasResource("objects/characters/female_npc_rachel_rachelmeadows.binmsh") &&
+								  _resources->hasResource("objects/characters/female_npc_serena_serenavaldivia.binmsh") &&
+								  _resources->hasResource("objects/characters/mr_scratch_mr_scratch.binmsh");
+	// check for film festival banner
+	bool hasFilmFestivalBanner = _resources->hasResource("objects/props/special/film_festival_banner_banner_med.binmsh");
+	// check for first level's sattelite
+	bool hasSatellite = _resources->hasResource("objects/props/special/level1_misc_satelite.binhvk") &&
+						_resources->hasResource("objects/props/special/level1_misc_satelite.binmsh");
+	// check for observatory posters
+	bool hasObservatoryPosters = _resources->hasResource("objects/props/special/observatory_posters_poster_01.binmsh") &&
+								 _resources->hasResource("objects/props/special/observatory_posters_poster_02.binmsh");
+	// check for leftover prototype buttons
+	bool hasPrototypeButtons = _resources->hasResource("objects/prototype/test_numbers_green_button.binmsh") &&
+							   _resources->hasResource("objects/prototype/test_numbers_red_button.binmsh");
+	// check for game's main level structures
+	bool hasNightmareComplexes = _resources->hasDirectory("objects/structures/complexes/driveintheater") &&
+								 _resources->hasDirectory("objects/structures/complexes/observatory") &&
+								 _resources->hasDirectory("objects/structures/complexes/reststop");
+	// check for Nightmare specific music
+	bool hasNightmareMusic = _resources->hasResource("sounds/music/licensed/club_foot_kasabian.fsb") &&
+							 _resources->hasResource("sounds/music/potf/potf_balance_slays_the_demon_game_edit.fsb") &&
+							 _resources->hasResource("sounds/music/potf/potf_psycho_game_edit.fsb") &&
+							 _resources->hasResource("sounds/music/potf/radio_show_03_music.fsb");
+	// check for arcade mode game worlds
+	bool hasArcadeWorlds = _resources->hasDirectory("worlds/gameworld/levels/arcade6_rim") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/arcade5_rim") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/arcade4_rim") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/arcade3_rim") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/arcade2_rim") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/arcade1_rim");
+	
+	if (hasArcadeWorlds && hasFilmFestivalBanner &&
+		hasNightmareCharacters && hasNightmareComplexes &&
+		hasNightmareMusic && hasObservatoryPosters &&
+		hasPrototypeButtons && hasSatellite) {
+		spdlog::debug("Looks like Alan Wake's American Nightmare!");
+		return kResultNightmare;
+	} else {
+		spdlog::debug("Doesn't look like Alan Wake's American Nightmare...");
+	 	return kResultUnknown;
+	}
+}
+
+ProbeResult Probe::checkQuantumBreak() {
+	// check for Microsoft product placement
+	bool hasMicrosoftProducts = _resources->hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_p_9ddbe72b.aaa") &&
+								_resources->hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_pro_mesh_000.nmb") &&
+								_resources->hasResource("objects/ringtail/batch39/microsoft_surface_surface_3_pro_tablet_without_keyboard.binfbx") &&
+								_resources->hasResource("objects/ringtail/batch45/microsoft_lumia_640.wedmsh");
+	// check for game levels
+	bool hasQBreakLevels = _resources->hasDirectory("worlds/gameworld/levels/sofias_island") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/university") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/shipyard") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/secretlab") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/old_riverport") &&
+						   _resources->hasDirectory("worlds/gameworld/levels/default");
+	// check for leftover whiteboxing prototype files
+	bool hasQBreakPrototype = _resources->hasDirectory("textures/whiteboxing_temp/monarch_hq/lods");
+	// check for time machine textures
+	bool hasTimeMachine = _resources->hasDirectory("textures/time_machine");
+	// check for Nissan Leaf product placement
+	bool hasNissanLeaf = _resources->hasResource("objects/ringtail/batch38/nissan_leaf_logos.wedmsh") &&
+						 _resources->hasResource("objects/ringtail/batch38/nissan_leaf_monarch.binhvk") &&
+						 _resources->hasResource("objects/ringtail/batch38/nissan_leaf_taxi.binhvk");
+	// check for Monarch HQ building
+	bool hasMonarchHQ = _resources->hasDirectory("objects/structures/monarch_hq");
+	// check for games characters
+	bool hasQBreakCharacters = _resources->hasDirectory("textures/characters/wiljoy") &&
+							   _resources->hasDirectory("textures/characters/jacjoy") &&
+							   _resources->hasDirectory("textures/characters/liabur") &&
+							   _resources->hasDirectory("textures/characters/nicmar");
+	
+	if (hasQBreakCharacters && hasQBreakPrototype &&
+		hasQBreakLevels && hasMicrosoftProducts &&
+		hasMonarchHQ && hasNissanLeaf && hasTimeMachine) {
+		spdlog::debug("Looks like Quantum Break!");
+		return kResultQuantumBreak;
+	} else {
+		spdlog::debug("Doesn't look like Quantum Break...");
+		return kResultUnknown;
+	}
+}

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -20,43 +20,47 @@
 
 #include <spdlog/spdlog.h>
 
+#include "src/awe/resman.h"
 #include "src/awe/rmdparchive.h"
-#include "probe.h"
+#include "src/common/exception.h"
+#include "src/probe.h"
 
-Probe::Probe() {
-	_resources = &ResMan;
-}
+Probe::Probe() {}
 
-unsigned char Probe::performProbe() {
+ProbeResult Probe::performProbe() {
 	spdlog::info("Probing archives...");
-	uint8_t allChecks = checkAlanWake() |
-						checkNightmare() |
-						checkQuantumBreak() |
-						checkAlanWakeRemastered();
-	if ((allChecks & (allChecks - 1)) != 0) // More that one successful check...
-		return kResultUnknown;
+	uint8_t allChecks = 
+					checkAlanWake() |
+					checkAmericanNightmare() |
+					checkQuantumBreak() |
+					checkAlanWakeRemastered();
+	if ((allChecks & (allChecks - 1)) != 0) // Zero or more that one successful checks...
+		if (allChecks == kResultUnknown)
+			return kResultUnknown;
+		else
+			throw CreateException("Ambiguous archives: probe failed to recognise a certain game");
 	else
-	 	return allChecks;
+	 	return static_cast<ProbeResult>(allChecks);
 }
 
 ProbeResult Probe::checkAlanWake() {
 	// check if old Alan Wake's textures are present in files
-	bool hasAlanWake2008 = _resources->hasDirectory("textures/characters/alanwake_2008");
+	bool hasAlanWake2008 = ResMan.hasDirectory("textures/characters/alanwake_2008");
 	// check for Stucky's texture variation
-	bool hasStuckyVar02 = _resources->hasDirectory("textures/characters/stucky_var02");
+	bool hasStuckyVar02 = ResMan.hasDirectory("textures/characters/stucky_var02");
 	// check for sponsored ads
-	bool hasVerizonCellPhone = _resources->hasResource("textures/objects/items/misc/cellphone_verizon_n.tex") &&
-							   _resources->hasResource("textures/objects/items/misc/cellphone_verizon.tex");
-	bool hasEnergizerBatteries = _resources->hasResource("textures/objects/items/lightsources/energizer_flashlight_test.tex") &&
-								 _resources->hasResource("textures/objects/items/lightsources/energizer_lithium.tex") &&
-								 _resources->hasResource("textures/objects/items/lightsources/energizer_max.tex");
+	bool hasVerizonCellPhone = ResMan.hasResource("textures/objects/items/misc/cellphone_verizon_n.tex") &&
+							   ResMan.hasResource("textures/objects/items/misc/cellphone_verizon.tex");
+	bool hasEnergizerBatteries = ResMan.hasResource("textures/objects/items/lightsources/energizer_flashlight_test.tex") &&
+								 ResMan.hasResource("textures/objects/items/lightsources/energizer_lithium.tex") &&
+								 ResMan.hasResource("textures/objects/items/lightsources/energizer_max.tex");
 	// check for "gameplay_example" meshes
-	bool hasGameplayExample = _resources->hasResource("objects/backdrop/gameplay_example_0_0.binmsh") &&
-							  _resources->hasResource("objects/backdrop/gameplay_example_3_3.binmsh");
+	bool hasGameplayExample = ResMan.hasResource("objects/backdrop/gameplay_example_0_0.binmsh") &&
+							  ResMan.hasResource("objects/backdrop/gameplay_example_3_3.binmsh");
 	// check for test breakable table mesh
-	bool hasBreakableTableTest = _resources->hasResource("objects/test/breakabletable_mesh.binmsh");
+	bool hasBreakableTableTest = ResMan.hasResource("objects/test/breakabletable_mesh.binmsh");
 	// check for Arial font
-	bool hasArial = _resources->hasResource("fonts/Arial.binfnt");
+	bool hasArial = ResMan.hasResource("fonts/Arial.binfnt");
 
 	if (hasArial && hasAlanWake2008 && hasBreakableTableTest &&
 		hasEnergizerBatteries && hasGameplayExample &&
@@ -71,38 +75,38 @@ ProbeResult Probe::checkAlanWake() {
 
 ProbeResult Probe::checkAlanWakeRemastered() {
 	// check for new deerfest parade truck textures
-	bool hasParadefloat = _resources->hasDirectory("textures/objects/vehicles/new/paradefloat/paradefloat");
+	bool hasParadefloat = ResMan.hasDirectory("textures/objects/vehicles/new/paradefloat/paradefloat");
 	// check for Rose's trailer items
-	bool hasRosesTrailer = _resources->hasResource("textures/objects/structures/complexes/trailerpark/rosestrailerpropsd3t.tex") &&
-						   _resources->hasResource("textures/objects/structures/complexes/trailerpark/rosepillow_d3t.tex") &&
-						   _resources->hasResource("textures/objects/structures/complexes/trailerpark/rosebedsheet_d3t.tex");
+	bool hasRosesTrailer = ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosestrailerpropsd3t.tex") &&
+						   ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosepillow_d3t.tex") &&
+						   ResMan.hasResource("textures/objects/structures/complexes/trailerpark/rosebedsheet_d3t.tex");
 	// check for complex Andersson's farm
-	bool hasComplexAnderssonsFarm = _resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/barnandersson") &&
-									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/mainbuilding") &&
-									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/rockstage") &&
-									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/threshingandersson") &&
-									_resources->hasDirectory("textures/objects/structures/complexes/anderssonfarm/windmillandersson");
+	bool hasComplexAnderssonsFarm = ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/barnandersson") &&
+									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/mainbuilding") &&
+									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/rockstage") &&
+									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/threshingandersson") &&
+									ResMan.hasDirectory("textures/objects/structures/complexes/anderssonfarm/windmillandersson");
 	// check for Zane's book covers
-	bool hasZaneBookCovers = _resources->hasResource("textures/objects/props/special/zane_books_covers.tex");
+	bool hasZaneBookCovers = ResMan.hasResource("textures/objects/props/special/zane_books_covers.tex");
 	// check for "missing" posters textures
-	bool hasMissingPosters = _resources->hasResource("textures/objects/props/special/missingposter_contestwinner_s.tex") &&
-							 _resources->hasResource("textures/objects/props/special/missing_campers_s.tex");
+	bool hasMissingPosters = ResMan.hasResource("textures/objects/props/special/missingposter_contestwinner_s.tex") &&
+							 ResMan.hasResource("textures/objects/props/special/missing_campers_s.tex");
 	// check for Alan Wake's sunglasses texture
-	bool hasAlanWakeSunglasses = _resources->hasResource("textures/objects/items/misc/alanwakesunglasses_s.tex");
+	bool hasAlanWakeSunglasses = ResMan.hasResource("textures/objects/items/misc/alanwakesunglasses_s.tex");
 	// check for intentional easter eggs
-	bool hasEasterEggs = _resources->hasResource("objects/props/special/easter_eggs_ahma_beer.binmsh") &&
-						 _resources->hasResource("objects/props/special/easter_eggs_coffee_world.binmsh") &&
-						 _resources->hasResource("objects/props/special/easter_eggs_fbc_letter.binmsh") &&
-						 _resources->hasResource("objects/props/special/easter_eggs_jim_figamore.binmsh") &&
-						 _resources->hasResource("objects/props/special/easter_eggs_kalevala_knights.binmsh") &&
-						 _resources->hasResource("objects/props/special/easter_eggs_tower_maintenance.binmsh") &&
-						 _resources->hasResource("objects/props/special/easter_eggs_watery_attractions.binmsh");
+	bool hasEasterEggs = ResMan.hasResource("objects/props/special/easter_eggs_ahma_beer.binmsh") &&
+						 ResMan.hasResource("objects/props/special/easter_eggs_coffee_world.binmsh") &&
+						 ResMan.hasResource("objects/props/special/easter_eggs_fbc_letter.binmsh") &&
+						 ResMan.hasResource("objects/props/special/easter_eggs_jim_figamore.binmsh") &&
+						 ResMan.hasResource("objects/props/special/easter_eggs_kalevala_knights.binmsh") &&
+						 ResMan.hasResource("objects/props/special/easter_eggs_tower_maintenance.binmsh") &&
+						 ResMan.hasResource("objects/props/special/easter_eggs_watery_attractions.binmsh");
 	// check for GDC '09 cinematic animations ?
-	bool hasGDC09Animations = _resources->hasResource("animations/male/alanwake/cinematic_gdc09_1100_wake.binhkx") &&
-							  _resources->hasResource("animations/male/barrywheeler/cinematic_gdc09_1100_barry.binhkx") &&
-							  _resources->hasResource("animations/male/lee/cinematic_gdc09_1300b_lee.binhkx") &&
-							  _resources->hasResource("animations/male/rusty/cinematic_gdc09_1300b_rusty.binhkx") &&
-							  _resources->hasResource("animations/female/alice/cinematic_gdc09_1050_alice.binhkx");
+	bool hasGDC09Animations = ResMan.hasResource("animations/male/alanwake/cinematic_gdc09_1100_wake.binhkx") &&
+							  ResMan.hasResource("animations/male/barrywheeler/cinematic_gdc09_1100_barry.binhkx") &&
+							  ResMan.hasResource("animations/male/lee/cinematic_gdc09_1300b_lee.binhkx") &&
+							  ResMan.hasResource("animations/male/rusty/cinematic_gdc09_1300b_rusty.binhkx") &&
+							  ResMan.hasResource("animations/female/alice/cinematic_gdc09_1050_alice.binhkx");
 
 	if (hasGDC09Animations && hasAlanWakeSunglasses &&
 		hasComplexAnderssonsFarm && hasEasterEggs &&
@@ -116,47 +120,47 @@ ProbeResult Probe::checkAlanWakeRemastered() {
 	}
 }
 
-ProbeResult Probe::checkNightmare() {
+ProbeResult Probe::checkAmericanNightmare() {
 	// check for game's characters
-	bool hasNightmareCharacters = _resources->hasResource("objects/characters/alanwake_awns_mesh.binmsh") &&
-								  _resources->hasResource("objects/characters/female_npc_emma_emmasloan.binmsh") &&
-								  _resources->hasResource("objects/characters/female_npc_rachel_rachelmeadows.binmsh") &&
-								  _resources->hasResource("objects/characters/female_npc_serena_serenavaldivia.binmsh") &&
-								  _resources->hasResource("objects/characters/mr_scratch_mr_scratch.binmsh");
+	bool hasNightmareCharacters = ResMan.hasResource("objects/characters/alanwake_awns_mesh.binmsh") &&
+								  ResMan.hasResource("objects/characters/female_npc_emma_emmasloan.binmsh") &&
+								  ResMan.hasResource("objects/characters/female_npc_rachel_rachelmeadows.binmsh") &&
+								  ResMan.hasResource("objects/characters/female_npc_serena_serenavaldivia.binmsh") &&
+								  ResMan.hasResource("objects/characters/mr_scratch_mr_scratch.binmsh");
 	// check for film festival banner
-	bool hasFilmFestivalBanner = _resources->hasResource("objects/props/special/film_festival_banner_banner_med.binmsh");
+	bool hasFilmFestivalBanner = ResMan.hasResource("objects/props/special/film_festival_banner_banner_med.binmsh");
 	// check for first level's sattelite
-	bool hasSatellite = _resources->hasResource("objects/props/special/level1_misc_satelite.binhvk") &&
-						_resources->hasResource("objects/props/special/level1_misc_satelite.binmsh");
+	bool hasSatellite = ResMan.hasResource("objects/props/special/level1_misc_satelite.binhvk") &&
+						ResMan.hasResource("objects/props/special/level1_misc_satelite.binmsh");
 	// check for observatory posters
-	bool hasObservatoryPosters = _resources->hasResource("objects/props/special/observatory_posters_poster_01.binmsh") &&
-								 _resources->hasResource("objects/props/special/observatory_posters_poster_02.binmsh");
+	bool hasObservatoryPosters = ResMan.hasResource("objects/props/special/observatory_posters_poster_01.binmsh") &&
+								 ResMan.hasResource("objects/props/special/observatory_posters_poster_02.binmsh");
 	// check for leftover prototype buttons
-	bool hasPrototypeButtons = _resources->hasResource("objects/prototype/test_numbers_green_button.binmsh") &&
-							   _resources->hasResource("objects/prototype/test_numbers_red_button.binmsh");
+	bool hasPrototypeButtons = ResMan.hasResource("objects/prototype/test_numbers_green_button.binmsh") &&
+							   ResMan.hasResource("objects/prototype/test_numbers_red_button.binmsh");
 	// check for game's main level structures
-	bool hasNightmareComplexes = _resources->hasDirectory("objects/structures/complexes/driveintheater") &&
-								 _resources->hasDirectory("objects/structures/complexes/observatory") &&
-								 _resources->hasDirectory("objects/structures/complexes/reststop");
+	bool hasNightmareComplexes = ResMan.hasDirectory("objects/structures/complexes/driveintheater") &&
+								 ResMan.hasDirectory("objects/structures/complexes/observatory") &&
+								 ResMan.hasDirectory("objects/structures/complexes/reststop");
 	// check for Nightmare specific music
-	bool hasNightmareMusic = _resources->hasResource("sounds/music/licensed/club_foot_kasabian.fsb") &&
-							 _resources->hasResource("sounds/music/potf/potf_balance_slays_the_demon_game_edit.fsb") &&
-							 _resources->hasResource("sounds/music/potf/potf_psycho_game_edit.fsb") &&
-							 _resources->hasResource("sounds/music/potf/radio_show_03_music.fsb");
+	bool hasNightmareMusic = ResMan.hasResource("sounds/music/licensed/club_foot_kasabian.fsb") &&
+							 ResMan.hasResource("sounds/music/potf/potf_balance_slays_the_demon_game_edit.fsb") &&
+							 ResMan.hasResource("sounds/music/potf/potf_psycho_game_edit.fsb") &&
+							 ResMan.hasResource("sounds/music/potf/radio_show_03_music.fsb");
 	// check for arcade mode game worlds
-	bool hasArcadeWorlds = _resources->hasDirectory("worlds/gameworld/levels/arcade6_rim") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/arcade5_rim") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/arcade4_rim") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/arcade3_rim") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/arcade2_rim") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/arcade1_rim");
+	bool hasArcadeWorlds = ResMan.hasDirectory("worlds/gameworld/levels/arcade6_rim") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/arcade5_rim") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/arcade4_rim") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/arcade3_rim") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/arcade2_rim") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/arcade1_rim");
 	
 	if (hasArcadeWorlds && hasFilmFestivalBanner &&
 		hasNightmareCharacters && hasNightmareComplexes &&
 		hasNightmareMusic && hasObservatoryPosters &&
 		hasPrototypeButtons && hasSatellite) {
 		spdlog::debug("Looks like Alan Wake's American Nightmare!");
-		return kResultNightmare;
+		return kResultAmericanNightmare;
 	} else {
 		spdlog::debug("Doesn't look like Alan Wake's American Nightmare...");
 	 	return kResultUnknown;
@@ -165,32 +169,32 @@ ProbeResult Probe::checkNightmare() {
 
 ProbeResult Probe::checkQuantumBreak() {
 	// check for Microsoft product placement
-	bool hasMicrosoftProducts = _resources->hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_p_9ddbe72b.aaa") &&
-								_resources->hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_pro_mesh_000.nmb") &&
-								_resources->hasResource("objects/ringtail/batch39/microsoft_surface_surface_3_pro_tablet_without_keyboard.binfbx") &&
-								_resources->hasResource("objects/ringtail/batch45/microsoft_lumia_640.wedmsh");
+	bool hasMicrosoftProducts = ResMan.hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_p_9ddbe72b.aaa") &&
+								ResMan.hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_pro_mesh_000.nmb") &&
+								ResMan.hasResource("objects/ringtail/batch39/microsoft_surface_surface_3_pro_tablet_without_keyboard.binfbx") &&
+								ResMan.hasResource("objects/ringtail/batch45/microsoft_lumia_640.wedmsh");
 	// check for game levels
-	bool hasQBreakLevels = _resources->hasDirectory("worlds/gameworld/levels/sofias_island") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/university") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/shipyard") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/secretlab") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/old_riverport") &&
-						   _resources->hasDirectory("worlds/gameworld/levels/default");
+	bool hasQBreakLevels = ResMan.hasDirectory("worlds/gameworld/levels/sofias_island") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/university") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/shipyard") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/secretlab") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/old_riverport") &&
+						   ResMan.hasDirectory("worlds/gameworld/levels/default");
 	// check for leftover whiteboxing prototype files
-	bool hasQBreakPrototype = _resources->hasDirectory("textures/whiteboxing_temp/monarch_hq/lods");
+	bool hasQBreakPrototype = ResMan.hasDirectory("textures/whiteboxing_temp/monarch_hq/lods");
 	// check for time machine textures
-	bool hasTimeMachine = _resources->hasDirectory("textures/time_machine");
+	bool hasTimeMachine = ResMan.hasDirectory("textures/time_machine");
 	// check for Nissan Leaf product placement
-	bool hasNissanLeaf = _resources->hasResource("objects/ringtail/batch38/nissan_leaf_logos.wedmsh") &&
-						 _resources->hasResource("objects/ringtail/batch38/nissan_leaf_monarch.binhvk") &&
-						 _resources->hasResource("objects/ringtail/batch38/nissan_leaf_taxi.binhvk");
+	bool hasNissanLeaf = ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_logos.wedmsh") &&
+						 ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_monarch.binhvk") &&
+						 ResMan.hasResource("objects/ringtail/batch38/nissan_leaf_taxi.binhvk");
 	// check for Monarch HQ building
-	bool hasMonarchHQ = _resources->hasDirectory("objects/structures/monarch_hq");
+	bool hasMonarchHQ = ResMan.hasDirectory("objects/structures/monarch_hq");
 	// check for games characters
-	bool hasQBreakCharacters = _resources->hasDirectory("textures/characters/wiljoy") &&
-							   _resources->hasDirectory("textures/characters/jacjoy") &&
-							   _resources->hasDirectory("textures/characters/liabur") &&
-							   _resources->hasDirectory("textures/characters/nicmar");
+	bool hasQBreakCharacters = ResMan.hasDirectory("textures/characters/wiljoy") &&
+							   ResMan.hasDirectory("textures/characters/jacjoy") &&
+							   ResMan.hasDirectory("textures/characters/liabur") &&
+							   ResMan.hasDirectory("textures/characters/nicmar");
 	
 	if (hasQBreakCharacters && hasQBreakPrototype &&
 		hasQBreakLevels && hasMicrosoftProducts &&

--- a/src/probe.h
+++ b/src/probe.h
@@ -24,11 +24,11 @@
 #include "src/awe/resman.h"
 
 enum ProbeResult {
-	kResultUnknown 				= 0,
-	kResultAlanWake 			= 1,
-	kResultNightmare 			= 2,
-	kResultQuantumBreak 		= 4,
-	kResultAlanWakeRemastered 	= 8,
+	kResultUnknown = 0,
+	kResultAlanWake = 1,
+	kResultAmericanNightmare = 2,
+	kResultQuantumBreak = 4,
+	kResultAlanWakeRemastered = 8,
 };
 
 class Probe {
@@ -41,7 +41,7 @@ public:
 	 * 
 	 * \return One of the ProbeResult values
 	 */
-	unsigned char performProbe();
+	ProbeResult performProbe();
 
 private:
 	/*!
@@ -54,7 +54,7 @@ private:
 	 * Checks whether supplied data archives are of
 	 * Alan Wake's American Nightmare
 	 */
-	ProbeResult checkNightmare();
+	ProbeResult checkAmericanNightmare();
 
 	/*!
 	 * Checks whether supplied data archives are of
@@ -67,8 +67,6 @@ private:
 	 * Alan Wake Remastered
 	 */
 	ProbeResult checkAlanWakeRemastered();
-	
-	AWE::RessourceManager* _resources;
 
 };
 

--- a/src/probe.h
+++ b/src/probe.h
@@ -1,0 +1,75 @@
+/* OpenAWE - A reimplementation of Remedys Alan Wake Engine
+ *
+ * OpenAWE is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * OpenAWE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * OpenAWE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenAWE. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef AWE_PROBE_H
+#define AWE_PROBE_H
+
+#include "src/awe/resman.h"
+
+enum ProbeResult {
+	kResultUnknown 				= 0,
+	kResultAlanWake 			= 1,
+	kResultNightmare 			= 2,
+	kResultQuantumBreak 		= 4,
+	kResultAlanWakeRemastered 	= 8,
+};
+
+class Probe {
+public:
+	Probe();
+
+	/*!
+	 * Checks game archives to find out what game data have been
+	 * supplied to the engine.
+	 * 
+	 * \return One of the ProbeResult values
+	 */
+	unsigned char performProbe();
+
+private:
+	/*!
+	 * Checks whether supplied data archives are of
+	 * original Alan Wake
+	 */
+	ProbeResult checkAlanWake();
+	
+	/*!
+	 * Checks whether supplied data archives are of
+	 * Alan Wake's American Nightmare
+	 */
+	ProbeResult checkNightmare();
+
+	/*!
+	 * Checks whether supplied data archives are of
+	 * Quantum Break
+	 */
+	ProbeResult checkQuantumBreak();
+
+	/*!
+	 * Checks whether supplied data archives are of
+	 * Alan Wake Remastered
+	 */
+	ProbeResult checkAlanWakeRemastered();
+	
+	AWE::RessourceManager* _resources;
+
+};
+
+#endif //AWE_PROBE_H


### PR DESCRIPTION
Adds Probe class to figure out which game's resources were provided to the engine. Checks for specific game assets for Alan Wake, Alan Wake's American Nightmare, Quantum Break and Alan Wake Remastered. Should be able to close #9.