### PR TITLE
Use workflow caches to shorten CI build time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' }}
         uses: actions/cache@v3
         with:
-          path: $VCPKG_DEFAULT_BINARY_CACHE
+          path: $VCPKG_INSTALLATION_ROOT\archives
           key: ${{matrix.os}}-build-vcpkg-cache-${{ github.ref_name }}
           restore-keys: |
             ${{matrix.os}}-build-vcpkg-cache-master
@@ -72,6 +72,15 @@ jobs:
         run: |
           brew update
           brew install zlib glfw libogg libvorbis theora spdlog glew openal-soft bullet fmt googletest tinyxml2 glm
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{github.workspace}}/build
+          key: ${{matrix.os}}-build-compile-cache-${{ github.ref_name }}
+          restore-keys: |
+            ${{matrix.os}}-build-compile-cache-master
+            ${{matrix.os}}-build-compile-cache-
 
       - name: Configure CMake
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,21 +61,23 @@ jobs:
         run: |
           mkdir vcpkg-cache
           echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg-cache" >> $GITHUB_ENV
+          vcpkg update
+          vcpkg install --dry-run zlib glfw3 libogg libvorbis libtheora spdlog glew openal-soft bullet3 fmt gtest tinyxml2 glm opengl >> vcpkg-cache/vcpkg_dry_run.txt
 
       - name: Cache dependencies for vcpkg
         if: ${{ matrix.os == 'windows-2019' }}
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/vcpkg-cache
-          key: ${{matrix.os}}-build-vcpkg-cache-${{ github.ref_name }}
+          key: ${{ matrix.os }}-build-vcpkg-cache-${{ github.ref_name }}-${{ hashFiles('vcpkg-cache/*') }}
           restore-keys: |
-            ${{matrix.os}}-build-vcpkg-cache-master
-            ${{matrix.os}}-build-vcpkg-cache-
+            ${{ matrix.os }}-build-vcpkg-cache-${{ github.ref_name }}-
+            ${{ matrix.os }}-build-vcpkg-cache-master-
+            ${{ matrix.os }}-build-vcpkg-cache-
 
       - name: Install dependencies with vcpkg
         if: ${{ matrix.os == 'windows-2019' }}
         run: |
-          vcpkg update
           vcpkg install zlib glfw3 libogg libvorbis libtheora spdlog glew openal-soft bullet3 fmt gtest tinyxml2 glm opengl
 
       - name: Install dependencies with brew
@@ -88,13 +90,12 @@ jobs:
         if: ${{ matrix.os != 'windows-2019' }}
         uses: actions/cache@v3
         with:
-          path: |
-            ${{github.workspace}}/build
-            ${{github.workspace}}/.ccache
-          key: ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-${{ github.ref_name }}
+          path: ${{github.workspace}}/.ccache
+          key: ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-${{ github.ref_name }}-${{ hashFiles('**/src/*.cpp', '**/src/*.h') }}
           restore-keys: |
-            ${{matrix.os}}-${{ matrix.compiler }}-build-compile-cache-master
-            ${{matrix.os}}-${{ matrix.compiler }}-build-compile-cache-
+            ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-${{ github.ref_name }}-
+            ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-master-
+            ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-
 
       - name: Setup ccache
         if: ${{ matrix.os != 'windows-2019' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on: ['push', 'pull_request']
 env:
   BUILD_TYPE: Release
   VCPKG_DEFAULT_TRIPLET: x64-windows
+  VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg-cache
+  CCACHE_BASEDIR: ${{ github.workspace }}
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_COMPRESS: true
+  CCACHE_COMPRESSLEVEL: 6
+  CCACHE_MAXSIZE: 400M
 
 jobs:
   build:
@@ -13,18 +19,18 @@ jobs:
           - name: Linux GCC
             os: ubuntu-20.04
             compiler: gcc
-            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           - name: Linux Clang
             os: ubuntu-20.04
             compiler: clang
-            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           - name: Windows MSVC
             os: windows-2019
             extra_cmake_args: -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
           - name: MacOS Clang
             os: macos-11
             compiler: clang
-            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include/AL
+            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include/AL
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -60,7 +66,6 @@ jobs:
         shell: bash
         run: |
           mkdir vcpkg-cache
-          echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg-cache" >> $GITHUB_ENV
           vcpkg update
           vcpkg install --dry-run zlib glfw3 libogg libvorbis libtheora spdlog glew openal-soft bullet3 fmt gtest tinyxml2 glm opengl >> vcpkg-cache/vcpkg_dry_run.txt
 
@@ -96,17 +101,6 @@ jobs:
             ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-${{ github.ref_name }}-
             ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-master-
             ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-
-
-      - name: Setup ccache
-        if: ${{ matrix.os != 'windows-2019' }}
-        shell: bash
-        run: |
-          echo "CCACHE_COMPILER=${{ matrix.compiler }}" >> $GITHUB_ENV
-          echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
-          echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
-          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
-          echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
-          echo "CCACHE_MAXSIZE=400M" >> $GITHUB_ENV
 
       - name: Configure CMake
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: ['push', 'pull_request']
 env:
   BUILD_TYPE: Release
   VCPKG_DEFAULT_TRIPLET: x64-windows
-  VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg-cache
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
   CCACHE_BASEDIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_COMPRESS: true
@@ -61,28 +61,19 @@ jobs:
             libgtest-dev \
             ccache
 
-      - name: Override cache folder for vcpkg
+      - name: Install dependencies with vcpkg
         if: ${{ matrix.os == 'windows-2019' }}
         shell: bash
         run: |
-          mkdir vcpkg-cache
           vcpkg update
-          vcpkg install --dry-run zlib glfw3 libogg libvorbis libtheora spdlog glew openal-soft bullet3 fmt gtest tinyxml2 glm opengl >> vcpkg-cache/vcpkg_dry_run.txt
-
-      - name: Cache dependencies for vcpkg
-        if: ${{ matrix.os == 'windows-2019' }}
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/vcpkg-cache
-          key: ${{ matrix.os }}-build-vcpkg-cache-${{ github.ref_name }}-${{ hashFiles('vcpkg-cache/*') }}
-          restore-keys: |
-            ${{ matrix.os }}-build-vcpkg-cache-${{ github.ref_name }}-
-            ${{ matrix.os }}-build-vcpkg-cache-master-
-            ${{ matrix.os }}-build-vcpkg-cache-
-
-      - name: Install dependencies with vcpkg
-        if: ${{ matrix.os == 'windows-2019' }}
-        run: |
+          nuget sources Add \
+            -source "https://nuget.pkg.github.com/${{ github.actor }}/index.json" \
+            -name "GitHub" \
+            -storepasswordincleartext \
+            -username "${{ github.actor }}" \
+            -password "${{ github.token }}"
+          nuget setapikey "${{ github.token }}" \
+            -source "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
           vcpkg install zlib glfw3 libogg libvorbis libtheora spdlog glew openal-soft bullet3 fmt gtest tinyxml2 glm opengl
 
       - name: Install dependencies with brew

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,16 @@ jobs:
             libglew-dev \
             libgtest-dev
 
+      - name: Cache dependencies for vcpkg
+        if: ${{ matrix.os == 'windows-2019' }}
+        uses: actions/cache@v3
+        with:
+          path: $VCPKG_DEFAULT_BINARY_CACHE
+          key: ${{matrix.os}}-build-vcpkg-cache-${{ github.ref_name }}
+          restore-keys: |
+            ${{matrix.os}}-build-vcpkg-cache-master
+            ${{matrix.os}}-build-vcpkg-cache-
+
       - name: Install dependencies with vcpkg
         if: ${{ matrix.os == 'windows-2019' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,18 @@ jobs:
             libgtest-dev \
             ccache
 
+      - name: Override cache folder for vcpkg
+        if: ${{ matrix.os == 'windows-2019' }}
+        shell: bash
+        run: |
+          mkdir '${{ github.workspace }}/vcpkg-cache'
+          export VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg-cache
+
       - name: Cache dependencies for vcpkg
         if: ${{ matrix.os == 'windows-2019' }}
         uses: actions/cache@v3
         with:
-          path: ${{ github.workspace }}/vcpkg/archives
+          path: ${{ github.workspace }}/vcpkg-cache
           key: ${{matrix.os}}-build-vcpkg-cache-${{ github.ref_name }}
           restore-keys: |
             ${{matrix.os}}-build-vcpkg-cache-master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,16 +12,19 @@ jobs:
         include:
           - name: Linux GCC
             os: ubuntu-20.04
-            extra_cmake_args: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            compiler: gcc
+            extra_cmake_args: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           - name: Linux Clang
             os: ubuntu-20.04
-            extra_cmake_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+            compiler: clang
+            extra_cmake_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           - name: Windows MSVC
             os: windows-2019
             extra_cmake_args: -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
           - name: MacOS Clang
             os: macos-11
-            extra_cmake_args: -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include/AL
+            compiler: clang
+            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include/AL
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -49,13 +52,14 @@ jobs:
             libvorbis-dev \
             libspdlog-dev \
             libglew-dev \
-            libgtest-dev
+            libgtest-dev \
+            ccache
 
       - name: Cache dependencies for vcpkg
         if: ${{ matrix.os == 'windows-2019' }}
         uses: actions/cache@v3
         with:
-          path: $VCPKG_INSTALLATION_ROOT\archives
+          path: ${{ github.workspace }}/vcpkg/archives
           key: ${{matrix.os}}-build-vcpkg-cache-${{ github.ref_name }}
           restore-keys: |
             ${{matrix.os}}-build-vcpkg-cache-master
@@ -71,16 +75,24 @@ jobs:
         if: ${{ matrix.os == 'macos-11' }}
         run: |
           brew update
-          brew install zlib glfw libogg libvorbis theora spdlog glew openal-soft bullet fmt googletest tinyxml2 glm
+          brew install zlib glfw libogg libvorbis theora spdlog glew openal-soft bullet fmt googletest tinyxml2 glm ccache
 
       - name: Cache build
+        if: ${{ matrix.os != 'windows-2019' }}
         uses: actions/cache@v3
         with:
-          path: ${{github.workspace}}/build
-          key: ${{matrix.os}}-build-compile-cache-${{ github.ref_name }}
+          path: |
+            ${{github.workspace}}/build
+            ${{github.workspace}}/.ccache
+          key: ${{ matrix.os }}-${{ matrix.compiler }}-build-compile-cache-${{ github.ref_name }}
           restore-keys: |
-            ${{matrix.os}}-build-compile-cache-master
-            ${{matrix.os}}-build-compile-cache-
+            ${{matrix.os}}-${{ matrix.compiler }}-build-compile-cache-master
+            ${{matrix.os}}-${{ matrix.compiler }}-build-compile-cache-
+
+      - name: Select compiler for ccache
+        if: ${{ matrix.os != 'windows-2019' }}
+        shell: bash
+        run: export CCACHE_COMPILER=${{ matrix.compiler }} 
 
       - name: Configure CMake
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ jobs:
           - name: Linux GCC
             os: ubuntu-20.04
             compiler: gcc
-            extra_cmake_args: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           - name: Linux Clang
             os: ubuntu-20.04
             compiler: clang
-            extra_cmake_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           - name: Windows MSVC
             os: windows-2019
             extra_cmake_args: -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
@@ -59,8 +59,8 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' }}
         shell: bash
         run: |
-          mkdir '${{ github.workspace }}/vcpkg-cache'
-          export VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg-cache
+          mkdir vcpkg-cache
+          echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg-cache" >> $GITHUB_ENV
 
       - name: Cache dependencies for vcpkg
         if: ${{ matrix.os == 'windows-2019' }}
@@ -84,7 +84,7 @@ jobs:
           brew update
           brew install zlib glfw libogg libvorbis theora spdlog glew openal-soft bullet fmt googletest tinyxml2 glm ccache
 
-      - name: Cache build
+      - name: Cache non-Windows build with ccache
         if: ${{ matrix.os != 'windows-2019' }}
         uses: actions/cache@v3
         with:
@@ -96,10 +96,16 @@ jobs:
             ${{matrix.os}}-${{ matrix.compiler }}-build-compile-cache-master
             ${{matrix.os}}-${{ matrix.compiler }}-build-compile-cache-
 
-      - name: Select compiler for ccache
+      - name: Setup ccache
         if: ${{ matrix.os != 'windows-2019' }}
         shell: bash
-        run: export CCACHE_COMPILER=${{ matrix.compiler }} 
+        run: |
+          echo "CCACHE_COMPILER=${{ matrix.compiler }}" >> $GITHUB_ENV
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=400M" >> $GITHUB_ENV
 
       - name: Configure CMake
         shell: bash


### PR DESCRIPTION
Use actions/cache Github Action together with ccache to reduce compilation time during frequent CI jobs on Mac and Linux. Can shorten build times (at the moment) from 10-15 minutes down to 2-4 on cache hit.
For Windows, use actions/cache to store vcpkg's build dependencies. Can shorten build times (right now) from 15-20 minutes down to 9-12 on cache hit. Unfortunately, it seems that ccache shouldn't be used with MSVC as it is not a thoroughly tested combination and thus unstable. 