### PR TITLE
Treat number of arguments as arguments byte length for function calls

### DIFF
--- a/src/awe/script/bytecode.cpp
+++ b/src/awe/script/bytecode.cpp
@@ -304,7 +304,7 @@ inline std::vector<Variable> Bytecode::extractParameters(byte argsBytes) {
 		if (_stack.empty())
 			break;
 		
-		if (std::get_if<entt::entity>(&_stack.top())) {
+		if (std::holds_alternative<entt::entity>(_stack.top())) {
 			bytesRemaining -= 2;
 		} else {
 			bytesRemaining--;
@@ -316,7 +316,7 @@ inline std::vector<Variable> Bytecode::extractParameters(byte argsBytes) {
 	arguments.shrink_to_fit();
 
 	if (bytesRemaining < 0)
-		throw CreateException("Parameter mismatch: expected to get {} values from stack but got {}", argsBytes, argsBytes - bytesRemaining);
+		throw CreateException("Parameter mismatch: expected to get {} data blocks from stack, got {}", argsBytes, argsBytes - bytesRemaining);
 	return arguments;
 }
 

--- a/src/awe/script/bytecode.h
+++ b/src/awe/script/bytecode.h
@@ -90,6 +90,8 @@ private:
 	void neq();
 	void eq();
 
+	inline std::vector<Variable> extractParameters(byte argsBytes);
+
 	bool _gt, _lt, _eq;
 
 	bool _stop;

--- a/src/awe/script/bytecode.h
+++ b/src/awe/script/bytecode.h
@@ -73,8 +73,8 @@ public:
 private:
 	void push();
 	void pushGID(Context &ctx);
-	void callGlobal(Context &ctx, const entt::entity &caller, byte numArgs, byte retType);
-	void callObject(Context &ctx, byte numArgs, byte retType);
+	void callGlobal(Context &ctx, const entt::entity &caller, byte argsBytes, byte retType);
+	void callObject(Context &ctx, byte argsBytes, byte retType);
 	void mulFloat();
 	void mulInt();
 	void ret();


### PR DESCRIPTION
While working on a PR for #13 I've noticed that some scripting functions are called with additional zero parameters not implied by message_defines. My currrent theory is that function calls store argument byte length inside their first parameter instead of a plain number of arguments, which leads to excessive array allocation in the current version of code. Here is a small patch to change this behaviour. It doesn't seem to break existing scripting functions since there aren't any implemented ones that have entities passed to them as an argument. 