### PR TITLE
Add variable to store rmdp archive path prefix

### DIFF
--- a/src/awe/resman.h
+++ b/src/awe/resman.h
@@ -42,6 +42,7 @@ namespace AWE {
  */
 class RessourceManager : public Common::Singleton<RessourceManager> {
 public:
+	void setPathPrefix(const std::string &pathPrefix);
 	void setRootPath(const std::string &rootPath);
 	void addPath(const std::string &path);
 
@@ -63,6 +64,7 @@ public:
 	Common::ReadStream *getResource(rid_t rid);
 
 private:
+	std::string _pathPrefix;
 	std::string _rootPath;
 	std::vector<std::unique_ptr<RIDProvider>> _meta;
 	std::vector<std::string> _paths;

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -122,8 +122,7 @@ std::optional<RMDPArchive::FileEntry> RMDPArchive::findFile(const FolderEntry &f
 }
 
 std::vector<size_t> RMDPArchive::getDirectoryResources(const std::string &directory) {
-	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(directory);
-	auto pathHashes = getPathHashes(path);
+	auto pathHashes = getPathHashes(directory);
 
 	auto maybeFolder = findDirectory(pathHashes);
 	if (!maybeFolder) return {};
@@ -177,9 +176,9 @@ std::string RMDPArchive::getResourcePath(size_t index) const {
 
 Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
 	std::lock_guard<std::mutex> g(_readMutex);
-	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(rid);
+
 	// Extract and separate file name from the rest of the path
-	auto pathHashes = getPathHashes(path);
+	auto pathHashes = getPathHashes(rid);
 	uint32_t fileHash = pathHashes.back();
 	pathHashes.pop_back();
 
@@ -204,9 +203,8 @@ Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
 }
 
 bool RMDPArchive::hasResource(const std::string &rid) const {
-	std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(rid);
 	// Extract and separate file name from the rest of the path
-	auto pathHashes = getPathHashes(path);
+	auto pathHashes = getPathHashes(rid);
 	uint32_t fileHash = pathHashes.back();
 	pathHashes.pop_back();
 
@@ -219,8 +217,7 @@ bool RMDPArchive::hasResource(const std::string &rid) const {
 }
 
 bool RMDPArchive::hasDirectory(const std::string &directory) const {
-	const std::string path = (_pathPrefix ? "d:/data/" : "") + AWE::getNormalizedPath(directory);
-	const auto pathHashes = getPathHashes(path);
+	const auto pathHashes = getPathHashes(directory);
 	const auto maybeFolder = findDirectory(pathHashes);
 	return maybeFolder.has_value();
 }

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -64,7 +64,6 @@ RMDPArchive::RMDPArchive(Common::ReadStream *bin, Common::ReadStream *rmdp) : _r
 			break;
 		case kVersionControl:
 			loadHeaderV8(bin, end);
-			_pathPrefix = false;
 			break;
 		default:
 			throw CreateException("Unknown RMDP Archive version {}", _version);
@@ -237,7 +236,6 @@ std::string RMDPArchive::readEntryName(Common::ReadStream *bin, int64_t offset, 
 
 void RMDPArchive::loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream &end) {
 	// Load header version 2, used by both Alan Wake and Alan Wake Remastered
-	_pathPrefix = false;
 
 	const uint32_t numFolders = end.readUint32();
 	const uint32_t numFiles = end.readUint32();
@@ -360,7 +358,6 @@ void RMDPArchive::loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream
 
 void RMDPArchive::loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream &end) {
 	// Load header version 7, used by Nightmare
-	_pathPrefix = true;
 
 	const uint32_t numFolders = end.readUint32();
 	const uint32_t numFiles = end.readUint32();
@@ -413,7 +410,6 @@ void RMDPArchive::loadHeaderV7(Common::ReadStream *bin, Common::EndianReadStream
 
 void RMDPArchive::loadHeaderV8(Common::ReadStream *bin, Common::EndianReadStream &end) {
 	// Load header version 8, used by Quantum Break
-	_pathPrefix = true;
 
 	const uint32_t numFolders = end.readUint32();
 	const uint32_t numFiles = end.readUint32();

--- a/src/awe/rmdparchive.h
+++ b/src/awe/rmdparchive.h
@@ -193,7 +193,6 @@ private:
 	 */
 	std::optional<FileEntry> findFile(const FolderEntry &folder, const uint32_t nameHash) const;
 
-	bool _pathPrefix;
 	bool _littleEndian;
 	uint32_t _version;
 

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -27,7 +27,7 @@
 #include "src/common/exception.h"
 #include "src/probe.h"
 
-constexpr std::array<std::string, kResultCount> _pathPrefixes = {
+const std::array<std::string, kResultCount> _pathPrefixes = {
 	"",		// kResultAlanWake
 	"",		// kResultAlanWakeRemastered
 	"d:/data/",	// kResultAmericanNightmare

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -27,7 +27,13 @@
 #include "src/common/exception.h"
 #include "src/probe.h"
 
-Probe::Probe() {}
+Probe::Probe() {
+	_pathPrefixes[kResultAlanWake] = "";
+	_pathPrefixes[kResultAlanWakeRemastered] = "d:/data/";
+	_pathPrefixes[kResultAmericanNightmare] = "d:/data/";
+	_pathPrefixes[kResultQuantumBreak] = "d:/data/";
+	_pathPrefixes[kResultControl] = "data/";
+}
 
 ProbeResult Probe::performProbe() {
 	spdlog::info("Probing archives...");
@@ -39,13 +45,17 @@ ProbeResult Probe::performProbe() {
 		checkControl();
 	if (allChecks.none())
 		return kResultUnknown;
-	else if (allChecks.count() == 1)
-		return static_cast<ProbeResult>(allChecks.to_ulong());
+	else if (allChecks.count() == 1) {
+		ProbeResult probeResult = static_cast<ProbeResult>(allChecks.to_ulong());
+		ResMan.setPathPrefix(_pathPrefixes[probeResult]); // Set the final path prefix
+		return probeResult;
+	}
 	else
-		throw CreateException("Ambiguous archives: probe failed to recognise a certain game");	 	
+		throw CreateException("Ambiguous archives: probe failed to recognise a certain game");
 }
 
 ProbeResult Probe::checkAlanWake() {
+	ResMan.setPathPrefix(_pathPrefixes[kResultAlanWake]);
 	// check if old Alan Wake's textures are present in files
 	bool hasAlanWake2008 = ResMan.hasDirectory("textures/characters/alanwake_2008");
 	// check for Stucky's texture variation
@@ -79,6 +89,7 @@ ProbeResult Probe::checkAlanWake() {
 }
 
 ProbeResult Probe::checkAlanWakeRemastered() {
+	ResMan.setPathPrefix(_pathPrefixes[kResultAlanWakeRemastered]);
 	// check for new deerfest parade truck textures
 	bool hasParadefloat = ResMan.hasDirectory("textures/objects/vehicles/new/paradefloat/paradefloat");
 	// check for Rose's trailer items
@@ -126,11 +137,13 @@ ProbeResult Probe::checkAlanWakeRemastered() {
 		return kResultAlanWakeRemastered;
 	} else {
 		spdlog::debug("Doesn't look like Alan Wake Remastered...");
+		ResMan.setPathPrefix(""); // reset pathPrefix
 		return kResultUnknown;
 	}
 }
 
 ProbeResult Probe::checkAmericanNightmare() {
+	ResMan.setPathPrefix(_pathPrefixes[kResultAmericanNightmare]);
 	// check for game's characters
 	bool hasNightmareCharacters = 
 		ResMan.hasResource("objects/characters/alanwake_awns_mesh.binmsh") &&
@@ -171,7 +184,7 @@ ProbeResult Probe::checkAmericanNightmare() {
 		ResMan.hasDirectory("worlds/gameworld/levels/arcade3_rim") &&
 		ResMan.hasDirectory("worlds/gameworld/levels/arcade2_rim") &&
 		ResMan.hasDirectory("worlds/gameworld/levels/arcade1_rim");
-	
+
 	if (hasArcadeWorlds && hasFilmFestivalBanner &&
 		hasNightmareCharacters && hasNightmareComplexes &&
 		hasNightmareMusic && hasObservatoryPosters &&
@@ -180,11 +193,13 @@ ProbeResult Probe::checkAmericanNightmare() {
 		return kResultAmericanNightmare;
 	} else {
 		spdlog::debug("Doesn't look like Alan Wake's American Nightmare...");
+		ResMan.setPathPrefix(""); // reset pathPrefix
 	 	return kResultUnknown;
 	}
 }
 
 ProbeResult Probe::checkQuantumBreak() {
+	ResMan.setPathPrefix(_pathPrefixes[kResultQuantumBreak]);
 	// check for Microsoft product placement
 	bool hasMicrosoftProducts = 
 		ResMan.hasResource("animations/intermediate/objects/ringtail/batch39/microsoft_surface_surface_3_p_9ddbe72b.aaa") &&
@@ -216,7 +231,7 @@ ProbeResult Probe::checkQuantumBreak() {
 		ResMan.hasDirectory("textures/characters/jacjoy") &&
 		ResMan.hasDirectory("textures/characters/liabur") &&
 		ResMan.hasDirectory("textures/characters/nicmar");
-	
+
 	if (hasQBreakCharacters && hasQBreakPrototype &&
 		hasQBreakLevels && hasMicrosoftProducts &&
 		hasMonarchHQ && hasNissanLeaf && hasTimeMachine) {
@@ -224,35 +239,38 @@ ProbeResult Probe::checkQuantumBreak() {
 		return kResultQuantumBreak;
 	} else {
 		spdlog::debug("Doesn't look like Quantum Break...");
+		ResMan.setPathPrefix(""); // reset pathPrefix
 		return kResultUnknown;
 	}
 }
 
 ProbeResult Probe::checkControl() {
+	ResMan.setPathPrefix(_pathPrefixes[kResultControl]);
 	// Check for Control missions
 	bool hasControlMissions =
-		ResMan.hasDirectory("data/worlds/gameworld/layers/hub_mission_01_the_bureau") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/hub_mission_02_the_hotline") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/maintenance_main_mission_03_lockdown") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/research_mission_04_marshall") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/maintenance_main_mission_05_blackrock") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/containment_main_mission_06_dylan") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/containment_main_mission_07_ordinary") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/maintenance_main_mission_08_ahti") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/research_mission_09_the_hedron") &&
-		ResMan.hasDirectory("data/worlds/gameworld/layers/hub_mission_10_nightmare");
+		ResMan.hasDirectory("worlds/gameworld/layers/hub_mission_01_the_bureau") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/hub_mission_02_the_hotline") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/maintenance_main_mission_03_lockdown") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/research_mission_04_marshall") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/maintenance_main_mission_05_blackrock") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/containment_main_mission_06_dylan") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/containment_main_mission_07_ordinary") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/maintenance_main_mission_08_ahti") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/research_mission_09_the_hedron") &&
+		ResMan.hasDirectory("worlds/gameworld/layers/hub_mission_10_nightmare");
 	// Check for mopping Ahti
 	bool hasAhti =
-		ResMan.hasResource("data/animations/intermediate/p7/human/male/ahti/ahti_mopping_loop_02.binanimclip");
+		ResMan.hasResource("animations/intermediate/p7/human/male/ahti/ahti_mopping_loop_02.binanimclip");
 	// Check for vending machine
 	bool hasVendingMachine =
-		ResMan.hasResource("data/objects/props/vending_machines/vending_machines_vending_machine.binfbx");
+		ResMan.hasResource("objects/props/vending_machines/vending_machines_vending_machine.binfbx");
 
 	if (hasControlMissions && hasAhti && hasVendingMachine) {
 		spdlog::debug("Looks like Control!");
 		return kResultControl;
 	} else {
 		spdlog::debug("Doesn't look like Control...");
+		ResMan.setPathPrefix(""); // reset pathPrefix
 		return kResultUnknown;
 	}
 }

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -29,7 +29,7 @@
 
 Probe::Probe() {
 	_pathPrefixes[kResultAlanWake] = "";
-	_pathPrefixes[kResultAlanWakeRemastered] = "d:/data/";
+	_pathPrefixes[kResultAlanWakeRemastered] = "";
 	_pathPrefixes[kResultAmericanNightmare] = "d:/data/";
 	_pathPrefixes[kResultQuantumBreak] = "d:/data/";
 	_pathPrefixes[kResultControl] = "data/";

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -137,7 +137,6 @@ ProbeResult Probe::checkAlanWakeRemastered() {
 		return kResultAlanWakeRemastered;
 	} else {
 		spdlog::debug("Doesn't look like Alan Wake Remastered...");
-		ResMan.setPathPrefix(""); // reset pathPrefix
 		return kResultUnknown;
 	}
 }
@@ -193,7 +192,6 @@ ProbeResult Probe::checkAmericanNightmare() {
 		return kResultAmericanNightmare;
 	} else {
 		spdlog::debug("Doesn't look like Alan Wake's American Nightmare...");
-		ResMan.setPathPrefix(""); // reset pathPrefix
 	 	return kResultUnknown;
 	}
 }
@@ -239,7 +237,6 @@ ProbeResult Probe::checkQuantumBreak() {
 		return kResultQuantumBreak;
 	} else {
 		spdlog::debug("Doesn't look like Quantum Break...");
-		ResMan.setPathPrefix(""); // reset pathPrefix
 		return kResultUnknown;
 	}
 }
@@ -270,7 +267,6 @@ ProbeResult Probe::checkControl() {
 		return kResultControl;
 	} else {
 		spdlog::debug("Doesn't look like Control...");
-		ResMan.setPathPrefix(""); // reset pathPrefix
 		return kResultUnknown;
 	}
 }

--- a/src/probe.h
+++ b/src/probe.h
@@ -75,6 +75,8 @@ private:
 	 */
 	ProbeResult checkControl();
 
+	std::map<ProbeResult, std::string> _pathPrefixes;
+
 };
 
 #endif //AWE_PROBE_H

--- a/src/probe.h
+++ b/src/probe.h
@@ -24,12 +24,13 @@
 #include "src/awe/resman.h"
 
 enum ProbeResult {
-	kResultUnknown = 0,
-	kResultAlanWake = 1,
-	kResultAmericanNightmare = 2,
-	kResultQuantumBreak = 4,
-	kResultAlanWakeRemastered = 8,
-	kResultControl = 16,
+	kResultAlanWake = 0,
+	kResultAlanWakeRemastered,
+	kResultAmericanNightmare,
+	kResultQuantumBreak,
+	kResultControl,
+	kResultUnknown,
+	kResultCount = kResultUnknown
 };
 
 class Probe {
@@ -49,33 +50,31 @@ private:
 	 * Checks whether supplied data archives are of
 	 * original Alan Wake
 	 */
-	ProbeResult checkAlanWake();
-	
+	bool checkAlanWake();
+
 	/*!
 	 * Checks whether supplied data archives are of
 	 * Alan Wake's American Nightmare
 	 */
-	ProbeResult checkAmericanNightmare();
+	bool checkAmericanNightmare();
 
 	/*!
 	 * Checks whether supplied data archives are of
 	 * Quantum Break
 	 */
-	ProbeResult checkQuantumBreak();
+	bool checkQuantumBreak();
 
 	/*!
 	 * Checks whether supplied data archives are of
 	 * Alan Wake Remastered
 	 */
-	ProbeResult checkAlanWakeRemastered();
+	bool checkAlanWakeRemastered();
 
 	/*!
 	 * Checks whether supplied data archives are of
 	 * Control
 	 */
-	ProbeResult checkControl();
-
-	std::map<ProbeResult, std::string> _pathPrefixes;
+	bool checkControl();
 
 };
 

--- a/test/test_awe_rmdparchive.cpp
+++ b/test/test_awe_rmdparchive.cpp
@@ -1850,27 +1850,27 @@ TEST(RMDPArchive, EmptyArchiveV7) {
 	AWE::RMDPArchive rmdpArchive(bin, rmdp);
 	EXPECT_EQ(rmdpArchive.getNumResources(), 0);
 
-	EXPECT_FALSE(rmdpArchive.hasDirectory("upper_test_folder"));
-	EXPECT_FALSE(rmdpArchive.hasDirectory("upper_test_folder/lower_test_folder"));
-	EXPECT_FALSE(rmdpArchive.hasDirectory("lower_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/upper_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/upper_test_folder/lower_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/lower_test_folder"));
 
-	EXPECT_FALSE(rmdpArchive.hasResource("test.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test2.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test4.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test2.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test4.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test2.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test4.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
-	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("test.txt"));
-	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("test4.txt"));
-	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test.txt"));
-	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("d:/data/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("d:/data/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("d:/data/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("d:/data/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
 	ASSERT_FALSE(test1);
 	ASSERT_FALSE(test2);
@@ -1897,27 +1897,27 @@ TEST(RMDPArchive, MultipleFilesArchiveV7) {
 	AWE::RMDPArchive rmdpArchive(bin, rmdp);
 	EXPECT_EQ(rmdpArchive.getNumResources(), 6);
 
-	EXPECT_TRUE(rmdpArchive.hasDirectory("upper_test_folder"));
-	EXPECT_TRUE(rmdpArchive.hasDirectory("upper_test_folder/lower_test_folder"));
-	EXPECT_FALSE(rmdpArchive.hasDirectory("lower_test_folder"));
+	EXPECT_TRUE(rmdpArchive.hasDirectory("d:/data/upper_test_folder"));
+	EXPECT_TRUE(rmdpArchive.hasDirectory("d:/data/upper_test_folder/lower_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/lower_test_folder"));
 
-	EXPECT_TRUE(rmdpArchive.hasResource("test.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("test2.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test4.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test2.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test4.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/test.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/test2.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test4.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
-	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("test.txt"));
-	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("test4.txt"));
-	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test.txt"));
-	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("d:/data/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("d:/data/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("d:/data/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("d:/data/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
 	ASSERT_TRUE(test1);
 	ASSERT_TRUE(test2);
@@ -1961,27 +1961,27 @@ TEST(RMDPArchive, EmptyArchiveV8) {
 	AWE::RMDPArchive rmdpArchive(bin, rmdp);
 	EXPECT_EQ(rmdpArchive.getNumResources(), 0);
 
-	EXPECT_FALSE(rmdpArchive.hasDirectory("upper_test_folder"));
-	EXPECT_FALSE(rmdpArchive.hasDirectory("upper_test_folder/lower_test_folder"));
-	EXPECT_FALSE(rmdpArchive.hasDirectory("lower_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/upper_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/upper_test_folder/lower_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/lower_test_folder"));
 
-	EXPECT_FALSE(rmdpArchive.hasResource("test.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test2.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test4.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test2.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test4.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test2.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test4.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
-	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("test.txt"));
-	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("test4.txt"));
-	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test.txt"));
-	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("d:/data/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("d:/data/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("d:/data/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("d:/data/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
 	ASSERT_FALSE(test1);
 	ASSERT_FALSE(test2);
@@ -2008,27 +2008,27 @@ TEST(RMDPArchive, MultipleFilesArchiveV8) {
 	AWE::RMDPArchive rmdpArchive(bin, rmdp);
 	EXPECT_EQ(rmdpArchive.getNumResources(), 6);
 
-	EXPECT_TRUE(rmdpArchive.hasDirectory("upper_test_folder"));
-	EXPECT_TRUE(rmdpArchive.hasDirectory("upper_test_folder/lower_test_folder"));
-	EXPECT_FALSE(rmdpArchive.hasDirectory("lower_test_folder"));
+	EXPECT_TRUE(rmdpArchive.hasDirectory("d:/data/upper_test_folder"));
+	EXPECT_TRUE(rmdpArchive.hasDirectory("d:/data/upper_test_folder/lower_test_folder"));
+	EXPECT_FALSE(rmdpArchive.hasDirectory("d:/data/lower_test_folder"));
 
-	EXPECT_TRUE(rmdpArchive.hasResource("test.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("test2.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("test4.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test2.txt"));
-	EXPECT_TRUE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test3.txt"));
-	EXPECT_FALSE(rmdpArchive.hasResource("upper_test_folder/lower_test_folder/test4.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/test.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/test2.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/test4.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	EXPECT_TRUE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	EXPECT_FALSE(rmdpArchive.hasResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
-	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("test.txt"));
-	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("test4.txt"));
-	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test.txt"));
-	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test2.txt"));
-	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test3.txt"));
-	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("upper_test_folder/lower_test_folder/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1(rmdpArchive.getResource("d:/data/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2(rmdpArchive.getResource("d:/data/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3(rmdpArchive.getResource("d:/data/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4(rmdpArchive.getResource("d:/data/test4.txt"));
+	std::unique_ptr<Common::ReadStream> test1_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test.txt"));
+	std::unique_ptr<Common::ReadStream> test2_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test2.txt"));
+	std::unique_ptr<Common::ReadStream> test3_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test3.txt"));
+	std::unique_ptr<Common::ReadStream> test4_2(rmdpArchive.getResource("d:/data/upper_test_folder/lower_test_folder/test4.txt"));
 
 	ASSERT_TRUE(test1);
 	ASSERT_TRUE(test2);


### PR DESCRIPTION
This proposal replaces the hardcoded prefix "d:/data/"  with a prefix variable _pathPrefix that can be specified per game.
The intention is to allow the use of "normalized" paths in the resource manager also for games like Control which use a /data/ folder in the rmdp archive instead of the "d:/data" prefix.
Some high res textures are stored in "/data_pc/" instead. A reminder has been added in the comments to possibly take this into account in the future.

