### PR TITLE
Add support for binfnt v7

### DIFF
--- a/src/graphics/images/dds.cpp
+++ b/src/graphics/images/dds.cpp
@@ -27,6 +27,15 @@ static const uint32_t DDS_DXT5 = MKTAG('D', 'X', 'T', '5');
 static const uint32_t DDS_DXT3 = MKTAG('D', 'X', 'T', '3');
 static const uint32_t DDS_DXT1 = MKTAG('D', 'X', 'T', '1');
 
+// DDS Pixel Format Flags
+static const uint32_t DDPF_ALPHAPIXELS = 0x00000001; // Texture contains alpha data; alphaBitMask contains valid data
+static const uint32_t DDPF_ALPHA       = 0x00000002; // Used in some older DDS files for alpha channel only uncompressed data
+static const uint32_t DDPF_FOURCC      = 0x00000004; // Texture contains compressed RGB data; fourCC contains valid data
+static const uint32_t DDPF_RGB         = 0x00000040; // Texture contains uncompressed RGB data; rgbBitCount and the RGB masks contain valid data
+static const uint32_t DDPF_YUV         = 0x00000200; // Used in some older DDS files for YUV uncompressed data
+static const uint32_t DDPF_LUMINANCE   = 0x00020000; // Used in some older DDS files for single channel color uncompressed data (e.g., grayscale)
+static const uint32_t DDPF_RGBA       =  DDPF_RGB | DDPF_ALPHAPIXELS; // Texture contains uncompressed RGBA/ARGB data
+
 namespace Graphics {
 
 DDS::DDS(Common::ReadStream *dds) {
@@ -55,29 +64,42 @@ DDS::DDS(Common::ReadStream *dds) {
 	uint32_t pixelFormatFlags = dds->readUint32LE();
 	uint32_t fourCC = dds->readUint32BE();
 
-	switch (fourCC) {
-		case DDS_DXT5:
-			_format = kBC3;
-			_compressed = true;
-			break;
-		case DDS_DXT3:
-			_format = kBC2;
-			_compressed = true;
-			break;
-		case DDS_DXT1:
-			_format = kBC1;
-			_compressed = true;
-			break;
-		default:
-			throw std::runtime_error("Invalid pixel format");
-	}
-
 	uint32_t rgbBitCount = dds->readUint32LE();
 
 	uint32_t redBitMask   = dds->readUint32LE();
 	uint32_t greenBitMask = dds->readUint32LE();
 	uint32_t blueBitMask  = dds->readUint32LE();
 	uint32_t alphaBitMask = dds->readUint32LE();
+
+	uint32_t bytesPerPixel;
+	if (pixelFormatFlags & DDPF_FOURCC) {
+		switch (fourCC) {
+			case DDS_DXT5:
+				_format = kBC3;
+				_compressed = true;
+				break;
+			case DDS_DXT3:
+				_format = kBC2;
+				_compressed = true;
+				break;
+			case DDS_DXT1:
+				_format = kBC1;
+				_compressed = true;
+				break;
+			default:
+				throw std::runtime_error("Unsupported dds pixel format - Unknown fourCC Code");
+		}
+	} else if ((pixelFormatFlags & DDPF_RGBA)
+				&& (redBitMask   == 0x00FF0000)
+				&& (greenBitMask == 0x0000FF00)
+				&& (blueBitMask  == 0x000000FF)
+				&& (alphaBitMask == 0xFF000000)
+			  ) {
+		_format = kRGBA8;
+		_compressed = false;
+		bytesPerPixel = 4;
+	} else
+		throw std::runtime_error("Unsupported dds pixel format");
 
 	dds->skip(20);
 
@@ -86,7 +108,12 @@ DDS::DDS(Common::ReadStream *dds) {
 		mipMap.width = width;
 		mipMap.height = height;
 
-		size_t dataSize = std::max(16u, ((width + 3u) / 4u) * ((height + 3u) / 4u) * 16u);
+		size_t dataSize;
+		if (_compressed) {
+			dataSize = std::max(16u, ((width + 3u) / 4u) * ((height + 3u) / 4u) * 16u);
+		} else {
+			dataSize = width * height * bytesPerPixel;
+		}
 
 		mipMap.data.resize(1);
 		mipMap.data[0].resize(dataSize);

--- a/src/graphics/images/dds.cpp
+++ b/src/graphics/images/dds.cpp
@@ -71,7 +71,6 @@ DDS::DDS(Common::ReadStream *dds) {
 	uint32_t blueBitMask  = dds->readUint32LE();
 	uint32_t alphaBitMask = dds->readUint32LE();
 
-	uint32_t bytesPerPixel;
 	if (pixelFormatFlags & DDPF_FOURCC) {
 		switch (fourCC) {
 			case DDS_DXT5:
@@ -97,7 +96,6 @@ DDS::DDS(Common::ReadStream *dds) {
 			  ) {
 		_format = kRGBA8;
 		_compressed = false;
-		bytesPerPixel = 4;
 	} else
 		throw std::runtime_error("Unsupported dds pixel format");
 
@@ -108,12 +106,7 @@ DDS::DDS(Common::ReadStream *dds) {
 		mipMap.width = width;
 		mipMap.height = height;
 
-		size_t dataSize;
-		if (_compressed) {
-			dataSize = std::max(16u, ((width + 3u) / 4u) * ((height + 3u) / 4u) * 16u);
-		} else {
-			dataSize = width * height * bytesPerPixel;
-		}
+		size_t dataSize = getImageSize(width, height);
 
 		mipMap.data.resize(1);
 		mipMap.data[0].resize(dataSize);


### PR DESCRIPTION
This PR adds support for binfnt v7 files and adds support for uncompressed RGB DDS textures.

This allows loading of the font/fixedsys.binfnt file as used in Control.
Binfnt v7 files can include kerning information but this info is ignored for now (it is not used in the fixedsys font).

Verified by using the Control fixedsys.binfnt as an asset when running Alan Wake AN with OpenAWE.