### PR TITLE
Fix infinite recursion when brokenmesh cannot be loaded

### DIFF
--- a/src/graphics/meshman.cpp
+++ b/src/graphics/meshman.cpp
@@ -50,7 +50,7 @@ MeshPtr MeshManager::getMesh(rid_t rid) {
 	if (iter == _meshRegistry.end()) {
 		std::unique_ptr<Common::ReadStream> meshResource(ResMan.getResource(rid));
 		if (!meshResource) {
-			spdlog::debug("Mesh {} is missing. Falling back to MissingMesh mesh.", rid);
+			spdlog::error("Mesh {} is missing. Falling back to MissingMesh mesh.", rid);
 			return getMissingMesh();
 		}
 
@@ -71,7 +71,7 @@ MeshPtr MeshManager::getMesh(const std::string &path) {
 	if (iter == _meshRegistry.end()) {
 		std::unique_ptr<Common::ReadStream> meshResource(ResMan.getResource(path));
 		if (!meshResource) {
-			spdlog::debug("Mesh {} is missing. Falling back to MissingMesh mesh.", path);
+			spdlog::error("Mesh {} is missing. Falling back to MissingMesh mesh.", path);
 			return getMissingMesh();
 		}
 
@@ -94,7 +94,7 @@ MeshPtr MeshManager::getMesh(const std::string &path, std::initializer_list<std:
 	if (iter == _meshRegistry.end()) {
 		std::unique_ptr<Common::ReadStream> meshResource(ResMan.getResource(path));
 		if (!meshResource) {
-			spdlog::debug("Mesh {} is missing. Falling back to MissingMesh mesh.", path);
+			spdlog::error("Mesh {} is missing. Falling back to MissingMesh mesh.", path);
 			return getMissingMesh();
 		}
 

--- a/src/graphics/meshman.cpp
+++ b/src/graphics/meshman.cpp
@@ -80,7 +80,9 @@ MeshPtr MeshManager::getMesh(const std::string &path) {
 			return _meshRegistry[path] = loader.load(*meshResource, {"depth", "material"});
 		} catch (std::exception &e) {
 			spdlog::error("Error while loading mesh \"{}\": {}", path, e.what());
-			return getBrokenMesh();
+			if (path != _brokenMeshPath)
+				return getBrokenMesh();
+			return nullptr;
 		}
 	} else {
 		return iter->second;
@@ -101,7 +103,9 @@ MeshPtr MeshManager::getMesh(const std::string &path, std::initializer_list<std:
 			return _meshRegistry[path] = loader.load(*meshResource, stages);
 		} catch (std::exception &e) {
 			spdlog::error("Error while loading mesh \"{}\": {}", path, e.what());
-			return getBrokenMesh();
+			if (path != _brokenMeshPath)
+				return getBrokenMesh();
+			return nullptr;
 		}
 	} else {
 		return iter->second;

--- a/src/graphics/meshman.cpp
+++ b/src/graphics/meshman.cpp
@@ -49,8 +49,10 @@ MeshPtr MeshManager::getMesh(rid_t rid) {
 	auto iter = _meshRegistry.find(rid);
 	if (iter == _meshRegistry.end()) {
 		std::unique_ptr<Common::ReadStream> meshResource(ResMan.getResource(rid));
-		if (!meshResource)
+		if (!meshResource) {
+			spdlog::debug("Mesh {} is missing. Falling back to MissingMesh mesh.", rid);
 			return getMissingMesh();
+		}
 
 		try {
 			const auto &loader = getMeshLoader(std::filesystem::path(ResMan.getResourcePath(rid)).extension().string());
@@ -68,8 +70,10 @@ MeshPtr MeshManager::getMesh(const std::string &path) {
 	auto iter = _meshRegistry.find(path);
 	if (iter == _meshRegistry.end()) {
 		std::unique_ptr<Common::ReadStream> meshResource(ResMan.getResource(path));
-		if (!meshResource)
+		if (!meshResource) {
+			spdlog::debug("Mesh {} is missing. Falling back to MissingMesh mesh.", path);
 			return getMissingMesh();
+		}
 
 		try {
 			const auto &loader = getMeshLoader(std::filesystem::path(path).extension().string());
@@ -87,8 +91,10 @@ MeshPtr MeshManager::getMesh(const std::string &path, std::initializer_list<std:
 	auto iter = _meshRegistry.find(path);
 	if (iter == _meshRegistry.end()) {
 		std::unique_ptr<Common::ReadStream> meshResource(ResMan.getResource(path));
-		if (!meshResource)
+		if (!meshResource) {
+			spdlog::debug("Mesh {} is missing. Falling back to MissingMesh mesh.", path);
 			return getMissingMesh();
+		}
 
 		try {
 			const auto &loader = getMeshLoader(std::filesystem::path(path).extension().string());

--- a/src/graphics/opengl/renderer.cpp
+++ b/src/graphics/opengl/renderer.cpp
@@ -681,6 +681,7 @@ void Renderer::drawSky() {
 	const auto stereoBuffer = skyProgram->getUniformLocation("g_sStereoBuffer");
 
 	const auto skyMesh = _sky->getSkyMesh();
+	assert(skyMesh);
 	const auto indices = std::static_pointer_cast<Graphics::OpenGL::VBO>(skyMesh->getIndices());
 
 	for (const auto &mesh: skyMesh->getMeshs()) {


### PR DESCRIPTION
Fixes an infinite recursion issue when Brokenmesh cannot be loaded (e.g. because the version of the file is not supported)