### PR TITLE
Fix crash in unrmdp

### DIFF
--- a/src/awe/path.cpp
+++ b/src/awe/path.cpp
@@ -34,4 +34,11 @@ std::string getNormalizedPath(const std::string &path) {
 	return lower;
 }
 
+std::string removeDrivePrefix(const std::string &path) {
+	if (path.size() > 2 && path[1] == ':' && path[2] == '/') {
+		return path.substr(3);
+	}
+	return path;
+}
+
 } // End of namespace AWE

--- a/src/awe/path.h
+++ b/src/awe/path.h
@@ -36,6 +36,16 @@ namespace AWE {
  */
 std::string getNormalizedPath(const std::string &path);
 
-};
+
+/*!
+* Function to remove the preceding drive letter, colon and root separator from the path
+*
+* \param path file path string to remove drive prefix from
+* \return path without drive prefix
+*/
+
+std::string removeDrivePrefix(const std::string &path);
+
+} // End of namespace AWE
 
 #endif // AWE_PATH_H

--- a/src/awe/resman.cpp
+++ b/src/awe/resman.cpp
@@ -102,7 +102,7 @@ std::vector<std::string> RessourceManager::getDirectoryResources(const std::stri
 	for (auto &archive : _archives) {
 		const auto indices = archive->getDirectoryResources(fullPath);
 		for (const auto &index: indices) {
-			paths.emplace_back(archive->getResourcePath(index));
+			paths.emplace_back(AWE::getNormalizedPath((archive->getResourcePath(index))));
 		}
 	}
 

--- a/src/awe/rmdparchive.cpp
+++ b/src/awe/rmdparchive.cpp
@@ -170,7 +170,7 @@ std::string RMDPArchive::getResourcePath(size_t index) const {
 			path = folderEntry.name + "/" + path;
 	}
 
-	return Common::replace(path, "d:/data/", "");
+	return path;
 }
 
 Common::ReadStream *RMDPArchive::getResource(const std::string &rid) const {
@@ -344,7 +344,7 @@ void RMDPArchive::loadHeaderV2(Common::ReadStream *bin, Common::EndianReadStream
 				throw CreateException("Invalid name hash: expected {}, but found {}",
 										entry.nameHash,
 										testHash);
-			
+
 			entry.offset = end.readUint64();
 			entry.size = end.readUint64();
 

--- a/tools/unrmdp.cpp
+++ b/tools/unrmdp.cpp
@@ -60,16 +60,16 @@ int main(int argc, char** argv) {
 
 	for (size_t i = 0; i < rmdp.getNumResources(); ++i) {
 		const std::string path = rmdp.getResourcePath(i);
-		const std::string normalizedPath = AWE::getNormalizedPath(path);
+		const std::string extractPath = AWE::removeDrivePrefix(path);
 
-		fmt::print("{}/{} {}\n", i + 1, rmdp.getNumResources(), normalizedPath);
+		fmt::print("{}/{} {} --> {}\n", i + 1, rmdp.getNumResources(), path, extractPath);
 
 		if (!onlyListFiles) {
 			const auto resourceStream = std::unique_ptr<Common::ReadStream>(rmdp.getResource(Common::toLower(path)));
-			if (!resourceStream.get())
+			if (!resourceStream)
 				throw Common::Exception("Resource not found in archive: {}", path);
 
-			std::filesystem::path p(normalizedPath);
+			std::filesystem::path p(extractPath);
 			if (!p.parent_path().empty())
 				std::filesystem::create_directories(p.parent_path());
 


### PR DESCRIPTION
Path prefixes are no longer handled in the RMDPArchive class since commit a37697f.  The unrmdp tool needs to be updated accordingly.