### PR TITLE
Enable mipmapping for textures that support it

### DIFF
--- a/src/graphics/images/tex.cpp
+++ b/src/graphics/images/tex.cpp
@@ -112,8 +112,8 @@ TEX::TEX(Common::ReadStream &tex) {
 		height /= 2;
 		depth /= 2;
 
-		width = std::max(width, 4u);
-		height = std::max(height, 4u);
+		width = std::max(width, 1u);
+		height = std::max(height, 1u);
 		depth = std::max(depth, 1u);
 	}
 }

--- a/src/graphics/opengl/texture.cpp
+++ b/src/graphics/opengl/texture.cpp
@@ -187,7 +187,12 @@ public:
 		TextureTask::apply();
 
 		glTexParameteri(_type, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(_type, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		if (decoder.getNumMipMaps() > 1) {
+			glTexParameteri(_type, GL_TEXTURE_MAX_LEVEL, decoder.getNumMipMaps() - 1);
+			glTexParameteri(_type, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		} else {
+			glTexParameteri(_type, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		}
 
 		glTexParameteri(_type, GL_TEXTURE_WRAP_S, GL_REPEAT);
 		glTexParameteri(_type, GL_TEXTURE_WRAP_T, GL_REPEAT);
@@ -324,7 +329,13 @@ class TexturePartLoadTask : public TextureTask {
 		TextureTask::apply();
 
 		glTexParameteri(_type, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(_type, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(_type, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		if (decoder.getNumMipMaps() > 1) {
+			glTexParameteri(_type, GL_TEXTURE_MAX_LEVEL, decoder.getNumMipMaps() - 1);
+			glTexParameteri(_type, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		} else {
+			glTexParameteri(_type, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		}
 
 		glTexParameteri(_type, GL_TEXTURE_WRAP_S, GL_REPEAT);
 		glTexParameteri(_type, GL_TEXTURE_WRAP_T, GL_REPEAT);


### PR DESCRIPTION
This PR sets `GL_TEXTURE_MIN_FILTER` to enable mipmapping for textures that support it. Textures with only one level will fall back to the previous setting of `GL_LINEAR`. It also tweaks the texture loading routine to allow properly loading textures/mipmaps smaller than 4x4. This is needed because the last two mipmap levels would otherwise be invalid.