### PR TITLE
Add missing include to graphics/opengl/task.h

### DIFF
--- a/src/graphics/opengl/task.h
+++ b/src/graphics/opengl/task.h
@@ -22,6 +22,7 @@
 #define OPENAWE_TASK_H
 
 #include <deque>
+#include <memory>
 
 #include "src/common/types.h"
 


### PR DESCRIPTION
This PR adds an include that was missing from `graphics/opengl/task.h`. This was causing a build error on my system (Fedora 41).